### PR TITLE
Default script tag to JavaScript for pretty printing if no type parameter is present (which is valid HTML5), so that CDATA is going to be commented out.

### DIFF
--- a/src/pprint.c
+++ b/src/pprint.c
@@ -1800,6 +1800,11 @@ void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *node )
             commentStart = VB_COMMENT_START;
             commentEnd = VB_COMMENT_END;
         }
+        else
+        {
+          commentStart = JS_COMMENT_START;
+          commentEnd = JS_COMMENT_END;
+        }
 
         hasCData = HasCDATA(doc->lexer, node->content);
 


### PR DESCRIPTION
Hey,

I have run into a quite worrying bug, seems that if there's a `<script>` tag without a `type` parameter – which is perfectly valid in HTML5 – Tidy will enclose the contents into an uncommented `CDATA` :(

Here's a very simple example which reproduces the error for me with Tidy compiled on Max OS X Lion 10.7.3 using the latest (1st March 2012 – 9412ef6eba886a3ec48ac95ce9f51503b176625b) commit.

Using...

`tidy --write-back yes test.html`

...on this:

```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-GB" lang="en-GB">


<head>

</head>

<body class=" x ">
<script>
    try { top.document.domain } catch (e) {
        var f = function() { document.body.innerHTML = ''; }
        setInterval(f,1);
        if (document.body) document.body.unload = f;
    }
</script>



<div id="skip-links">
    <p class="skip-link-p">
        Skip to: 
        <a accesskey="1" class="skip-link" href="#content">content</a>, 
        <a accesskey="2" class="skip-link" href="#nav-links">navigation</a>
    </p>
</div>


</body>
</html>
```

...results in this:

```

<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-GB" lang=
"en-GB">
<head>
<meta name="generator" content=
"HTML Tidy for Mac OS X https://github.com/w3c/tidy-html5/tree/f2825b9" />
<title></title>
</head>
<body class=" x">
<script>
<![CDATA[
        try { top.document.domain } catch (e) {
                var f = function() { document.body.innerHTML = ''; }
                setInterval(f,1);
                if (document.body) document.body.unload = f;
        }
]]>
</script>
<div id="skip-links">
<p class="skip-link-p">Skip to: <a accesskey="1" class="skip-link"
href="#content">content</a>, <a accesskey="2" class="skip-link"
href="#nav-links">navigation</a></p>
</div>
</body>
</html>
```
