### PR TITLE
GetVersFromFPI NULL string

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -180,7 +180,7 @@ static uint GetVersFromFPI(ctmbstr fpi)
     uint i;
 
     for (i = 0; W3C_Doctypes[i].name; ++i)
-        if (TY_(tmbstrcasecmp)(W3C_Doctypes[i].fpi, fpi) == 0)
+        if (W3C_Doctypes[i].fpi != NULL && TY_(tmbstrcasecmp)(W3C_Doctypes[i].fpi, fpi) == 0)
             return W3C_Doctypes[i].vers;
 
     return 0;


### PR DESCRIPTION
The GetVersFromFPI functions uses a NULL pointer from the HTML5 entries in W3C_Doctypes which specify NULL for the public identifier:

```
  { 20, HT50, "HTML5", NULL, NULL },
  { 21, XH50, "XHTML5", NULL, NULL },
```
