### PR TITLE
Better MSVC 2010 fix for CleanGoogleDocument unresolved externals.

### DIFF
--- a/build/msvc2010/tidydll.vcxproj
+++ b/build/msvc2010/tidydll.vcxproj
@@ -273,6 +273,12 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\src\gdoc.c">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="tidy.def" />
@@ -302,6 +308,7 @@
     <ClInclude Include="..\..\src\utf8.h" />
     <ClInclude Include="..\..\src\version.h" />
     <ClInclude Include="..\..\src\win32tc.h" />
+    <ClInclude Include="..\..\src\gdoc.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/msvc2010/tidylib.vcxproj
+++ b/build/msvc2010/tidylib.vcxproj
@@ -270,6 +270,13 @@
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\src\gdoc.c">
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UndefinePreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(UndefinePreprocessorDefinitions)</UndefinePreprocessorDefinitions>
+      <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\access.h" />
@@ -296,6 +303,7 @@
     <ClInclude Include="..\..\src\utf8.h" />
     <ClInclude Include="..\..\src\version.h" />
     <ClInclude Include="..\..\src\win32tc.h" />
+    <ClInclude Include="..\..\src\gdoc.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1281,7 +1281,7 @@ int         tidyDocCleanAndRepair( TidyDocImpl* doc )
         TY_(CleanDocument)( doc );
 
     /* clean up html exported by Google Focs */
-#if 0
+#if 1
     if ( gdoc )
         TY_(CleanGoogleDocument)( doc );
 #endif


### PR DESCRIPTION
My previous fix just commented out the google docs 'clean' functionality...  The root cause of that issue was that gdoc.h and gdoc.c were not being included in the msvc2010 project file.

This fix includes those files and re-enables the google docs 'clean' functionality.

(It looks like in my merge there were some whitespace differences that have to be merged too :( )
