### PR TITLE
Use a hash table for anchors

### DIFF
--- a/src/attrs.h
+++ b/src/attrs.h
@@ -122,7 +122,7 @@ Bool TY_(IsValidHTMLID)(ctmbstr id);
 Bool TY_(IsValidXMLID)(ctmbstr id);
 
 /* removes anchor for specific node */
-void TY_(RemoveAnchorByNode)( TidyDocImpl* doc, Node *node );
+void TY_(RemoveAnchorByNode)( TidyDocImpl* doc, ctmbstr name, Node *node );
 
 /* free all anchors */
 void TY_(FreeAnchors)( TidyDocImpl* doc );

--- a/src/attrs.h
+++ b/src/attrs.h
@@ -55,10 +55,15 @@ struct _AttrHash
 typedef struct _AttrHash AttrHash;
 #endif
 
+enum
+{
+    ANCHOR_HASH_SIZE=1021u
+};
+
 struct _TidyAttribImpl
 {
     /* anchor/node lookup */
-    Anchor*    anchor_list;
+    Anchor*    anchor_hash[ANCHOR_HASH_SIZE];
 
     /* Declared literal attributes */
     Attribute* declared_attr_list;

--- a/src/clean.c
+++ b/src/clean.c
@@ -2638,17 +2638,19 @@ void TY_(FixAnchors)(TidyDocImpl* doc, Node *node, Bool wantName, Bool wantId)
 
             if (id && !wantId
                 /* make sure that Name has been emitted if requested */
-                && (hadName || !wantName || NameEmitted) )
+                && (hadName || !wantName || NameEmitted) ) {
+                if (!wantId && !wantName)
+                    TY_(RemoveAnchorByNode)(doc, id->value, node);
                 TY_(RemoveAttribute)(doc, node, id);
+            }
 
             if (name && !wantName
                 /* make sure that Id has been emitted if requested */
-                && (hadId || !wantId || IdEmitted) )
+                && (hadId || !wantId || IdEmitted) ) {
+                if (!wantId && !wantName)
+                    TY_(RemoveAnchorByNode)(doc, name->value, node);
                 TY_(RemoveAttribute)(doc, node, name);
-
-            if (TY_(AttrGetById)(node, TidyAttr_NAME) == NULL &&
-                TY_(AttrGetById)(node, TidyAttr_ID) == NULL)
-                TY_(RemoveAnchorByNode)(doc, node);
+            }
         }
 
         if (node->content)

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1077,7 +1077,7 @@ void TY_(FreeAttrs)( TidyDocImpl* doc, Node *node )
             if ( (attrIsID(av) || attrIsNAME(av)) &&
                  TY_(IsAnchorElement)(doc, node) )
             {
-                TY_(RemoveAnchorByNode)( doc, node );
+                TY_(RemoveAnchorByNode)( doc, av->value, node );
             }
         }
 


### PR DESCRIPTION
This patch greatly improves performance on documents containing a large number of id/name attributes by using a hash table instead of a linked list while checking for duplicate ids.