### PR TITLE
Make messages passed into the callback filter localizable 

### DIFF
--- a/include/tidy.h
+++ b/include/tidy.h
@@ -619,9 +619,15 @@ TIDY_EXPORT void TIDY_CALL tidyPutByte( TidyOutputSink* sink, uint byteValue );
 typedef Bool (TIDY_CALL *TidyReportFilter)( TidyDoc tdoc, TidyReportLevel lvl,
                                            uint line, uint col, ctmbstr mssg );
 
+typedef Bool (TIDY_CALL *TidyReportFilter2)( TidyDoc tdoc, TidyReportLevel lvl,
+										   uint line, uint col, ctmbstr mssg, va_list args );
+
 /** Give Tidy a filter callback to use */
 TIDY_EXPORT Bool TIDY_CALL    tidySetReportFilter( TidyDoc tdoc,
                                                   TidyReportFilter filtCallback );
+
+TIDY_EXPORT Bool TIDY_CALL    tidySetReportFilter2( TidyDoc tdoc,
+												  TidyReportFilter2 filtCallback );
 
 /** Set error sink to named file */
 TIDY_EXPORT FILE* TIDY_CALL   tidySetErrorFile( TidyDoc tdoc, ctmbstr errfilnam );
@@ -852,7 +858,7 @@ TIDY_EXPORT uint TIDY_CALL tidyNodeColumn( TidyNode tnod );
 
 /** @defgroup NodeIsElementName Deprecated node interrogation per TagId
 **
-** @deprecated The functions tidyNodeIs{ElementName} are deprecated and 
+** @deprecated The functions tidyNodeIs{ElementName} are deprecated and
 ** should be replaced by tidyNodeGetId.
 ** @{
 */
@@ -954,7 +960,7 @@ TIDY_EXPORT Bool TIDY_CALL tidyAttrIsProp( TidyAttr tattr );
 
 /** @defgroup AttrIsAttributeName Deprecated attribute interrogation per AttrId
 **
-** @deprecated The functions  tidyAttrIs{AttributeName} are deprecated and 
+** @deprecated The functions  tidyAttrIs{AttributeName} are deprecated and
 ** should be replaced by tidyAttrGetId.
 ** @{
 */
@@ -1019,7 +1025,7 @@ TIDY_EXPORT TidyAttr TIDY_CALL tidyAttrGetById( TidyNode tnod, TidyAttrId attId 
 
 /** @defgroup AttrGetAttributeName Deprecated attribute retrieval per AttrId
 **
-** @deprecated The functions tidyAttrGet{AttributeName} are deprecated and 
+** @deprecated The functions tidyAttrGet{AttributeName} are deprecated and
 ** should be replaced by tidyAttrGetById.
 ** For instance, tidyAttrGetID( TidyNode tnod ) can be replaced by 
 ** tidyAttrGetById( TidyNode tnod, TidyAttr_ID ). This avoids a potential

--- a/src/localize.c
+++ b/src/localize.c
@@ -1028,6 +1028,8 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level,
 
     if ( go )
     {
+		va_list args_copy;
+		va_copy(args_copy, args);
         TY_(tmbvsnprintf)(messageBuf, sizeMessageBuf, msg, args);
         if ( doc->mssgFilt )
         {
@@ -1037,7 +1039,7 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level,
         if ( doc->mssgFilt2 )
         {
             TidyDoc tdoc = tidyImplToDoc( doc );
-            go = doc->mssgFilt2( tdoc, level, line, col, msg, args );
+            go = doc->mssgFilt2( tdoc, level, line, col, msg, args_copy );
         }
     }
 

--- a/src/localize.c
+++ b/src/localize.c
@@ -1034,6 +1034,11 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level,
             TidyDoc tdoc = tidyImplToDoc( doc );
             go = doc->mssgFilt( tdoc, level, line, col, messageBuf );
         }
+        if ( doc->mssgFilt2 )
+        {
+            TidyDoc tdoc = tidyImplToDoc( doc );
+            go = doc->mssgFilt2( tdoc, level, line, col, msg, args );
+        }
     }
 
     if ( go )

--- a/src/localize.c
+++ b/src/localize.c
@@ -1039,7 +1039,7 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level,
         if ( doc->mssgFilt2 )
         {
             TidyDoc tdoc = tidyImplToDoc( doc );
-            go = doc->mssgFilt2( tdoc, level, line, col, msg, args_copy );
+            go = go | doc->mssgFilt2( tdoc, level, line, col, msg, args_copy );
         }
     }
 

--- a/src/tidy-int.h
+++ b/src/tidy-int.h
@@ -48,6 +48,7 @@ struct _TidyDocImpl
     StreamOut*          docOut;
     StreamOut*          errout;
     TidyReportFilter    mssgFilt;
+    TidyReportFilter2   mssgFilt2;
     TidyOptCallback     pOptCallback;
 
     /* Parse + Repair Results */

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -649,6 +649,18 @@ Bool TIDY_CALL        tidySetReportFilter( TidyDoc tdoc, TidyReportFilter filt )
   return no;
 }
 
+Bool TIDY_CALL        tidySetReportFilter2( TidyDoc tdoc, TidyReportFilter2 filt )
+{
+	TidyDocImpl* impl = tidyDocToImpl( tdoc );
+	if ( impl )
+	{
+		impl->mssgFilt2 = filt;
+		return yes;
+	}
+	return no;
+}
+
+
 #if 0   /* Not yet */
 int         tidySetContentOutputSink( TidyDoc tdoc, TidyOutputSink* outp )
 {


### PR DESCRIPTION
Implements a TidyReportFilter2 that passes all of the separate strings to the filter callback function instead of an assembled string, making it possible to localize each of the individual strings in the application layer that is using TidyLib.

This avoids having to localize `localize.c` and makes it possible to use the host OS' built-in localization methods in the host OS environment.
