### PR TITLE
Change Unicode to UTF-16

### DIFF
--- a/build/readme.txt
+++ b/build/readme.txt
@@ -34,7 +34,7 @@ Option                        Default   Description
 ----------------------------  --------  ---------------------------------
 DMALLOC                       Disabled  Use dmalloc for memory debugging
 SUPPORT_ACCESSIBILITY_CHECKS  Enabled   Support W3C WAI checks
-SUPPORT_UTF16_ENCODINGS       Enabled   Support Unicode documents
+SUPPORT_UTF16_ENCODINGS       Enabled   Support UTF-16 documents
 SUPPORT_ASIAN_ENCODINGS       Enabled   Support Big5 and ShiftJIS docs
 
 


### PR DESCRIPTION
Unicode is already supported via UTF-8,
what is supported with this flag is the transfer format UTF-16,
which commonly misnamed Unicode, e.g. in the Microsoft Developer Documentation.