### PR TITLE
Makefile: fix spelling of .PHONEY -> .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GITFLAGS=
 DOXYGEN=doxygen
 DOXYGENFLAGS=
 
-.PHONEY: api-docs
+.PHONY: api-docs
 all: bin/tidy
 
 bin/tidy:


### PR DESCRIPTION
IMHO the "PHONY" option is written .PHONY