### PR TITLE
Fix for #196: HTML5 allows block elements in <CAPTION>

### DIFF
--- a/src/tags.c
+++ b/src/tags.c
@@ -184,7 +184,7 @@ static Dict tag_defs[] =
   { TidyTag_BODY,       "body",       VERS_ELEM_BODY,       &TY_(W3CAttrsFor_BODY)[0],       (CM_HTML|CM_OPT|CM_OMITST),                    TY_(ParseBody),     NULL           },
   { TidyTag_BR,         "br",         VERS_ELEM_BR,         &TY_(W3CAttrsFor_BR)[0],         (CM_INLINE|CM_EMPTY),                          TY_(ParseEmpty),    NULL           },
   { TidyTag_BUTTON,     "button",     VERS_ELEM_BUTTON,     &TY_(W3CAttrsFor_BUTTON)[0],     (CM_INLINE),                                   TY_(ParseBlock),    NULL           },
-  { TidyTag_CAPTION,    "caption",    VERS_ELEM_CAPTION,    &TY_(W3CAttrsFor_CAPTION)[0],    (CM_TABLE),                                    TY_(ParseInline),   CheckCaption   },
+  { TidyTag_CAPTION,    "caption",    VERS_ELEM_CAPTION,    &TY_(W3CAttrsFor_CAPTION)[0],    (CM_TABLE),                                    TY_(ParseBlock),    CheckCaption   },
   { TidyTag_CENTER,     "center",     VERS_ELEM_CENTER,     &TY_(W3CAttrsFor_CENTER)[0],     (CM_BLOCK),                                    TY_(ParseBlock),    NULL           },
   { TidyTag_CITE,       "cite",       VERS_ELEM_CITE,       &TY_(W3CAttrsFor_CITE)[0],       (CM_INLINE),                                   TY_(ParseInline),   NULL           },
   { TidyTag_CODE,       "code",       VERS_ELEM_CODE,       &TY_(W3CAttrsFor_CODE)[0],       (CM_INLINE),                                   TY_(ParseInline),   NULL           },
@@ -742,6 +742,20 @@ void TY_(AdjustTags)( TidyDocImpl *doc )
     {
         np->parser = TY_(ParseInline);
         np->model  = CM_INLINE;
+#if ELEMENT_HASH_LOOKUP
+        tagsEmptyHash( doc, tags );
+#endif
+    }
+
+/*\
+ * Issue #196
+ * TidyTag_CAPTION allows %flow; in HTML5,
+ * but only %inline; in HTML4
+\*/
+    np = (Dict *)TY_(LookupTagDef)( TidyTag_CAPTION );
+    if (np)
+    {
+        np->parser = TY_(ParseInline);
 #if ELEMENT_HASH_LOOKUP
         tagsEmptyHash( doc, tags );
 #endif


### PR DESCRIPTION
@geoffmcl Here is a patch for the issue reported earlier. Solved it the same way you did in #169.
Best regards, willydee