### PR TITLE
Fix #158 - remove inserted newlines in pre

### DIFF
--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2162,14 +2162,12 @@ void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
             PPrintTag( doc, mode, indent, node );
 
             indent = 0;
-            TY_(PFlushLine)( doc, indent );
 
             for ( content = node->content; content; content = content->next )
             {
                 TY_(PPrintTree)( doc, (mode | PREFORMATTED | NOWRAP),
                                  indent, content );
             }
-            PCondFlushLine( doc, indent );
             indent = indprev;
             PPrintEndTag( doc, mode, indent, node );
 


### PR DESCRIPTION
I believe these two lines are the source of the extra newlines within the pre tag.