### PR TITLE
Reordered Windows Includes

### DIFF
--- a/src/mappedio.c
+++ b/src/mappedio.c
@@ -97,15 +97,15 @@ void TY_(freeFileSource)( TidyInputSource* inp, Bool closeIt )
 
 
 #if defined(_WIN32)
-#include "streamio.h"
-#include "tidy-int.h"
-#include "message.h"
-
-#include <errno.h>
 #if defined(_MSC_VER) && (_MSC_VER < 1300)  /* less than msvc++ 7.0 */
 #pragma warning(disable:4115) /* named type definition in parentheses in windows headers */
 #endif
 #include <windows.h>
+#include <errno.h>
+
+#include "streamio.h"
+#include "tidy-int.h"
+#include "message.h"
 
 typedef struct _fp_input_mapped_source
 {


### PR DESCRIPTION
Moved the `<windows.h>` include above the "streamio.h" include to fix compilation with the latest Windows SDK.

`<winnt.h>` now has the following struct. In particular the `CR` member of this struct conflicts with a define in streamio.h.

    typedef struct _IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY {
        DWORD BeginAddress;
        union {
            DWORD UnwindData;
            struct {
                DWORD Flag : 2;
                DWORD FunctionLength : 11;
                DWORD RegF : 3;
                DWORD RegI : 4;
                DWORD H : 1;
                // The following line causes a compile error because CR is redefined in
                // streamio.h
                DWORD CR : 2;
                DWORD FrameSize : 9;
            } DUMMYSTRUCTNAME;
        } DUMMYUNIONNAME;
    } IMAGE_ARM64_RUNTIME_FUNCTION_ENTRY, * PIMAGE_ARM64_RUNTIME_FUNCTION_ENTRY;