### PR TITLE
Drop unnecessary semicolons from includes in example.

### DIFF
--- a/build/documentation/examples/example.1.c
+++ b/build/documentation/examples/example.1.c
@@ -1,9 +1,9 @@
 
 
-#include <tidy.h>;
-#include <buffio.h>;
-#include <stdio.h>;
-#include <errno.h>;
+#include <tidy.h>
+#include <buffio.h>
+#include <stdio.h>
+#include <errno.h>
 
 int main(int argc, char **argv )
 {

--- a/build/documentation/examples/example.1.c
+++ b/build/documentation/examples/example.1.c
@@ -1,7 +1,7 @@
 
 
 #include <tidy.h>
-#include <buffio.h>
+#include <tidybuffio.h>
 #include <stdio.h>
 #include <errno.h>
 

--- a/documentation/examples/example.1.c
+++ b/documentation/examples/example.1.c
@@ -1,9 +1,9 @@
 
 
-#include <tidy.h>;
-#include <tidybuffio.h>;
-#include <stdio.h>;
-#include <errno.h>;
+#include <tidy.h>
+#include <tidybuffio.h>
+#include <stdio.h>
+#include <errno.h>
 
 int main(int argc, char **argv )
 {


### PR DESCRIPTION
These semicolons are almost certainly harmless, but they are not idiomatic in C.

None of the real code appears to follow this convention of having semicolons after each `#include`, so it seemed strange for them to be included in the example code.