### PR TITLE
fixed: tidy-html5 debug build fails on VS2015 x64

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -86,7 +86,7 @@ void TIDY_CALL TY_(filesink_putByte)( void* sinkData, byte bv )
   FILE* fout = (FILE*) sinkData;
   fputc( bv, fout );
 #if !defined(NDEBUG) && defined(_MSC_VER)
-  if (fout->_file != 2)
+  if (_fileno(fout) != 2)
     SPRTF("%c",bv);
 #endif
 }


### PR DESCRIPTION
The debug build fails when building on Windows 10 x64 using Visual Studio 2010 (64-bit build).