### PR TITLE
Dockerfile for tidy-html5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+from ubuntu:14.04
+MAINTAINER Edward M. Vielmetti <edward.vielmetti@gmail.com>
+
+# install prerequisites
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    curl \
+    zip \
+    xsltproc \
+    doxygen \
+    rpm \
+    git
+
+# grab the tarball
+WORKDIR /root
+RUN curl -L -o 5.1.9.zip https://github.com/htacg/tidy-html5/archive/5.1.9.zip && \
+    unzip 5.1.9.zip
+
+# do the build
+# build everything I possibly can
+
+WORKDIR /root/tidy-html5-5.1.9/build/cmake 
+RUN cmake ../.. && make 
+
+WORKDIR /root/tidy-html5-5.1.9/build/documentation
+RUN cp ../cmake/tidy ../cmake/tidy5 && ./build_docs.sh
+
+WORKDIR /root/tidy-html5-5.1.9/build/cmake 
+RUN make package && make install 
+
+# run the command
+CMD "/usr/local/bin/tidy"


### PR DESCRIPTION
My first pass at a Dockerfile for this project. It downloads the 5.1.9 release, brings in all of the dependencies, builds all of the binaries and libraries, creates documentation, and builds an RPM and DEB for the platform it's on.

A couple of todos are left:
- it should probably build from the git "master" branch instead of a specific release
- if you were doing this in production you'd strip a lot of stuff out of it
- the base image could be much smaller than Ubuntu

This does completely automate a build from scratch.