### PR TITLE
Change "tidy5" to "tidy" in documentation build script

### DIFF
--- a/build/documentation/build_docs.sh
+++ b/build/documentation/build_docs.sh
@@ -7,7 +7,7 @@
 # documentation. Relative path is okay. You shouldn't have to change this
 # too often if your compiler always puts tidy in the same place.
 
-TIDY_PATH="../cmake/tidy5"         # Current directory.
+TIDY_PATH="../cmake/tidy"         # Current directory.
 
 TIDY_VERSION=`cat ../../version.txt`
 


### PR DESCRIPTION
Remove last vestige of old "tidy5" binary name.

With this change, automated documentation builds will work from source.