### PR TITLE
Update testhtml5 to use 'tidy' and not 'tidy5'

### DIFF
--- a/test/html5/testhtml5.sh
+++ b/test/html5/testhtml5.sh
@@ -19,7 +19,7 @@ failed()
 	TMPCNT3=$((${TMPCNT3} + 1));
 }
 
-TMPEXE="../../build/cmake/tidy5"
+TMPEXE="../../build/cmake/tidy"
 [ -e ${TMPEXE} ] || noexe
 
 TMPINP=temphtml5.cfg


### PR DESCRIPTION
testhtml5 does not work until you reference the proper executable.