### PR TITLE
Use tidy.xsl from documentation/ instead of build/documentation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,10 +213,14 @@ if (UNIX)
         ## also could use `manpath` command output to determine target install path
         set(TIDY_MANFILE ${LIB_NAME}.1)
         message(STATUS "*** Generating man ${TIDY_MANFILE} custom commands...")
-        set(TIDY1XSL ${CMAKE_CURRENT_SOURCE_DIR}/build/documentation/tidy1.xsl)
+        set(TIDY1XSL ${CMAKE_CURRENT_BINARY_DIR}/documentation/tidy1.xsl)
         set(TIDYHELP ${CMAKE_CURRENT_BINARY_DIR}/tidy-help.xml)
         set(TIDYCONFIG ${CMAKE_CURRENT_BINARY_DIR}/tidy-config.xml)
         add_custom_target(man ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}")
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/documentation/tidy1.xsl.in
+            ${TIDY1XSL}
+        )
  
         # run built EXE to generate xml output 
         add_custom_command(

--- a/documentation/tidy1.xsl.in
+++ b/documentation/tidy1.xsl.in
@@ -24,7 +24,7 @@
     the $CONFIG variable, declared here:
 -->
 
-<xsl:variable name="CONFIG" select="document('tidy-config.xml')"/>
+<xsl:variable name="CONFIG" select="document('@TIDYCONFIG@')"/>
 
 
 <!-- Main Template: -->


### PR DESCRIPTION
As we discussed, this is the second pull request to fix the warning during the build. I'm not sure I can delete the build/ directory yet. I tried and the project still builds fine, but I don't know if it's used elsewhere. If it can be safely removed, just let me know and I'll make one more commit.