### PR TITLE
Fix indent-with-tabs for library use.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1229,10 +1229,8 @@ Bool ParseTabs( TidyDocImpl* doc, const TidyOptionImpl* entry )
         Bool tabs = flag != 0 ? yes : no;
         TY_(SetOptionBool)( doc, entry->id, tabs );
         if (tabs) {
-            TY_(PPrintTabs)();
             TY_(SetOptionInt)( doc, TidyIndentSpaces, 1 );
         } else {
-            TY_(PPrintSpaces)();
             /* optional - TY_(ResetOptionToDefault)( doc, TidyIndentSpaces ); */
         }
     }

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1809,7 +1809,13 @@ int         tidyDocSaveStream( TidyDocImpl* doc, StreamOut* out )
     Bool asciiChars   = cfgBool(doc, TidyAsciiChars);
     Bool makeBare     = cfgBool(doc, TidyMakeBare);
     Bool escapeCDATA  = cfgBool(doc, TidyEscapeCdata);
+    Bool ppWithTabs   = cfgBool(doc, TidyPPrintTabs);
     TidyAttrSortStrategy sortAttrStrat = cfg(doc, TidySortAttributes);
+
+    if (ppWithTabs)
+        TY_(PPrintTabs)();
+    else
+        TY_(PPrintSpaces)();
 
     if (escapeCDATA)
         TY_(ConvertCDATANodes)(doc, &doc->root);


### PR DESCRIPTION
Posted as PR for code review.

When using libtidy the `config.c`'s `ParseTabs` (and other parsers) aren't used when setting properties with `tidyOptSetBool` (and other `tidyOptSet`ters), so this caused `indent-with-tabs` not to work. 

`tidylib.c` `tidyDocSaveToStream` are where most of the other option conditionals already exist so this seems like a likely home.

Fix verified using a `tidy.cfg` on the command line, and in Balthisar Tidy using `libtidy.dylib`.