### PR TITLE
Don't mangle the output filename

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -929,7 +929,10 @@ Bool TY_(ParseConfigValue)( TidyDocImpl* doc, TidyOptionId optId, ctmbstr optval
         TidyBuffer inbuf;            /* Set up input source */
         tidyBufInitWithAllocator( &inbuf, doc->allocator );
         tidyBufAttach( &inbuf, (byte*)optval, TY_(tmbstrlen)(optval)+1 );
-        doc->config.cfgIn = TY_(BufferInput)( doc, &inbuf, ASCII );
+        if (optId == TidyOutFile)
+            doc->config.cfgIn = TY_(BufferInput)( doc, &inbuf, RAW );
+        else
+            doc->config.cfgIn = TY_(BufferInput)( doc, &inbuf, ASCII );
         doc->config.c = GetC( &doc->config );
 
         status = option->parser( doc, option );


### PR DESCRIPTION
(originally from https://bugzilla.redhat.com/show_bug.cgi?id=720221)
Fixes #294 

When using '-output' option with Chinese file name, the created output file name is incorrect.

By using the following command:
```
$ touch 中文.html
$ /usr/bin/tidy -f 中文.html.stderr -output 中文.html.stdout 中文.html
$ ls
中??!.html.stdout  中文.html  中文.html.stderr
```
Actual results:
```
$ ls
中??!.html.stdout  中文.html  中文.html.stderr
'中文.html.stdout' becomes '中??!.html.stdout'.
```
Expected results:
```
$ ls
中文.html.stdout  中文.html  中文.html.stderr
'中文.html.stdout' becomes '中文.html.stdout'.
```