### PR TITLE
Allows null value css-prefix to be used in a config file without issu…

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1206,7 +1206,10 @@ Bool ParseCSS1Selector( TidyDocImpl* doc, const TidyOptionImpl* option )
     }
     buf[i] = '\0';
 
-    if ( i == 0 || !TY_(IsCSS1Selector)(buf) ) {
+    if ( i == 0 ) {
+        return no;
+    }
+    else if ( !TY_(IsCSS1Selector)(buf) ) {
         TY_(ReportBadArgument)( doc, option->name );
         return no;
     }


### PR DESCRIPTION
…ing a warning.

Fixes a case when an auto-generated tidy config file with a null `css-prefix` generated a warning about a malformed option value. Other tidy strings can accept null values.