### PR TITLE
Progress callback

### DIFF
--- a/include/tidy.h
+++ b/include/tidy.h
@@ -631,6 +631,9 @@ TIDY_EXPORT Bool TIDY_CALL tidyInitSink( TidyOutputSink* sink,
 TIDY_EXPORT void TIDY_CALL tidyPutByte( TidyOutputSink* sink, uint byteValue );
 
 
+/****************
+   Errors
+****************/
 /** Callback to filter messages by diagnostic level:
 **  info, warning, etc.  Just set diagnostic output 
 **  handler to redirect all diagnostics output.  Return true
@@ -655,6 +658,18 @@ TIDY_EXPORT FILE* TIDY_CALL   tidySetErrorFile( TidyDoc tdoc, ctmbstr errfilnam 
 TIDY_EXPORT int TIDY_CALL     tidySetErrorBuffer( TidyDoc tdoc, TidyBuffer* errbuf );
 /** Set error sink to given generic sink */
 TIDY_EXPORT int TIDY_CALL     tidySetErrorSink( TidyDoc tdoc, TidyOutputSink* sink );
+
+
+/****************
+   Printing
+****************/
+/** Callback to track the progress of the pretting printing process.
+**
+*/
+typedef Bool (TIDY_CALL *TidyPPProgress)( TidyDoc tdoc, uint line, uint col, uint destLine );
+
+TIDY_EXPORT Bool TIDY_CALL   tidySetPrettyPrinterCallback( TidyDoc tdoc,
+                                                  TidyPPProgress callback );
 
 /** @} end IO group */
 

--- a/include/tidy.h
+++ b/include/tidy.h
@@ -666,7 +666,7 @@ TIDY_EXPORT int TIDY_CALL     tidySetErrorSink( TidyDoc tdoc, TidyOutputSink* si
 /** Callback to track the progress of the pretting printing process.
 **
 */
-typedef Bool (TIDY_CALL *TidyPPProgress)( TidyDoc tdoc, uint line, uint col, uint destLine );
+typedef void (TIDY_CALL *TidyPPProgress)( TidyDoc tdoc, uint line, uint col, uint destLine );
 
 TIDY_EXPORT Bool TIDY_CALL   tidySetPrettyPrinterCallback( TidyDoc tdoc,
                                                   TidyPPProgress callback );

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2118,15 +2118,13 @@ void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
     Node *content, *last;
     uint spaces = cfg( doc, TidyIndentSpaces );
     Bool xhtml = cfgBool( doc, TidyXhtmlOut );
-    uint lastline = 0;
 
     if ( node == NULL )
         return;
 
     if (doc->progressCallback)
     {
-        if (doc->pprint.line > lastline)
-            doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line );
+        doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line );
     }
 
     if (node->type == TextNode)

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -312,6 +312,7 @@ void TY_(InitPrintBuf)( TidyDocImpl* doc )
     InitIndent( &doc->pprint.indent[0] );
     InitIndent( &doc->pprint.indent[1] );
     doc->pprint.allocator = doc->allocator;
+    doc->pprint.line = 0;
 }
 
 void TY_(FreePrintBuf)( TidyDocImpl* doc )
@@ -613,6 +614,7 @@ static void WrapLine( TidyDocImpl* doc )
         TY_(WriteChar)( '\\', doc->docOut );
 
     TY_(WriteChar)( '\n', doc->docOut );
+    pprint->line++;
     ResetLineAfterWrap( pprint );
 }
 
@@ -666,6 +668,7 @@ static void WrapAttrVal( TidyDocImpl* doc )
         TY_(WriteChar)( ' ', doc->docOut );
 
     TY_(WriteChar)( '\n', doc->docOut );
+    pprint->line++;
     ResetLineAfterWrap( pprint );
 }
 
@@ -686,7 +689,7 @@ static void PFlushLineImpl( TidyDocImpl* doc )
 
     for ( i = 0; i < pprint->linelen; ++i )
         TY_(WriteChar)( pprint->linebuf[i], doc->docOut );
-    
+
     if ( IsInString(pprint) )
         TY_(WriteChar)( '\\', doc->docOut );
     ResetLine( pprint );
@@ -701,6 +704,7 @@ void TY_(PFlushLine)( TidyDocImpl* doc, uint indent )
         PFlushLineImpl( doc );
 
     TY_(WriteChar)( '\n', doc->docOut );
+    pprint->line++;
     pprint->indent[ 0 ].spaces = indent;
 }
 
@@ -713,6 +717,7 @@ static void PCondFlushLine( TidyDocImpl* doc, uint indent )
          PFlushLineImpl( doc );
 
          TY_(WriteChar)( '\n', doc->docOut );
+         pprint->line++;
          pprint->indent[ 0 ].spaces = indent;
     }
 }
@@ -733,6 +738,7 @@ void TY_(PFlushLineSmart)( TidyDocImpl* doc, uint indent )
     /* Issue #228 - cfgBool( doc, TidyVertSpace ); */
     if(TidyAddVS) {
         TY_(WriteChar)( '\n', doc->docOut );
+        pprint->line++;
     }
 
     pprint->indent[ 0 ].spaces = indent;
@@ -749,6 +755,7 @@ static void PCondFlushLineSmart( TidyDocImpl* doc, uint indent )
          /* Issue #228 - cfgBool( doc, TidyVertSpace ); */
          if(TidyAddVS) {
             TY_(WriteChar)( '\n', doc->docOut );
+            pprint->line++;
          }
 
          pprint->indent[ 0 ].spaces = indent;

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2124,7 +2124,7 @@ void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
 
     if (doc->progressCallback)
     {
-        doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line );
+        doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line + 1 );
     }
 
     if (node->type == TextNode)
@@ -2391,6 +2391,11 @@ void TY_(PPrintXMLTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
     if (node == NULL)
         return;
 
+    if (doc->progressCallback)
+    {
+        doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line + 1 );
+    }
+    
     if ( node->type == TextNode)
     {
         PPrintText( doc, mode, indent, node );

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2118,9 +2118,16 @@ void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
     Node *content, *last;
     uint spaces = cfg( doc, TidyIndentSpaces );
     Bool xhtml = cfgBool( doc, TidyXhtmlOut );
+    uint lastline = 0;
 
     if ( node == NULL )
         return;
+
+    if (doc->progressCallback)
+    {
+        if (doc->pprint.line > lastline)
+            doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line );
+    }
 
     if (node->type == TextNode)
     {

--- a/src/pprint.h
+++ b/src/pprint.h
@@ -53,6 +53,7 @@ typedef struct _TidyPrintImpl
     uint lbufsize;
     uint linelen;
     uint wraphere;
+    uint line;
   
     uint ixInd;
     TidyIndent indent[2];  /* Two lines worth of indent state */

--- a/src/tidy-int.h
+++ b/src/tidy-int.h
@@ -59,6 +59,7 @@ struct _TidyDocImpl
     TidyReportFilter    mssgFilt;
     TidyReportFilter2   mssgFilt2;
     TidyOptCallback     pOptCallback;
+    TidyPPProgress      progressCallback;
 
     /* Parse + Repair Results */
     uint                optionErrors;

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -752,6 +752,19 @@ int TIDY_CALL    tidySetErrorSink( TidyDoc tdoc, TidyOutputSink* sink )
     return -EINVAL;
 }
 
+/* Use TidyPPProgress to monitor the progress of the pretty printer.
+ */
+Bool TIDY_CALL        tidySetPrettyPrinterCallback(TidyDoc tdoc, TidyPPProgress callback)
+{
+    TidyDocImpl* impl = tidyDocToImpl( tdoc );
+    if ( impl )
+    {
+        impl->progressCallback = callback;
+        return yes;
+    }
+    return no;
+}
+
 
 /* Document info */
 int TIDY_CALL        tidyStatus( TidyDoc tdoc )


### PR DESCRIPTION
Adds a callback to the pretty printer for tidylib users to report where items in the source text ended up in the destination text.

A potential use case is for GUI applications to synchronize scrolling of "before" and "after" text editors.
