### PR TITLE
Link to node-libtidy

### DIFF
--- a/index/_posts/1970-07-01-tidy_plus.md
+++ b/index/_posts/1970-07-01-tidy_plus.md
@@ -20,6 +20,10 @@ child nodes, and a pretty print output. This is a list of just a few application
 - [mod_tidy][20] is a **`libtidy`** based DSO module for Apache 2.0 that parses, cleans up,
   and pretty-prints the web server (X)HTML output. [Read more…][21]
 
+- [node-libtidy][node-libtidy] provides server-side JavaScript bindings for libtidy.
+  It aims to provide not only a high-level interface to a complete tidy run,
+  but also offers methods which closely model the **`libtidy`** interface.
+
 - [tidy-test][30] is a set of sample applications that exercise various aspects of the **`libtidy`**
   API. And always looking for more `samples`. It also includes a CMake module, [FindTidy.cmake][31]
   to be able to find installed Tidy headers and library for the compile link.
@@ -55,6 +59,6 @@ add it. You will want to edit [this file][2].
 [31]: https://github.com/geoffmcl/tidy-test/blob/master/CMakeModules/FindTidy.cmake
 
 [40]: https://notepad-plus-plus.org/
-
+[node-libtidy]: https://github.com/gagern/node-libtidy
 [41]: https://www.htmlvalidator.com/
 


### PR DESCRIPTION
I've recently started a new [project with node bindings for libtidy](https://github.com/gagern/node-libtidy). Not just a complete tidy run, but lower level interfaces as well. This is a *very* young project, so I can understand if you might not want to add a link to that just now. It would be OK with me to keep this pull request open for a while as a reminder while you wait and see how things evolve.

On the other hand, having various language bindings listed here would in my opinion be a good thing, and from all the contenders I looked at, I think my implementation is already the one offering the most flexible connection to many parts of the library. So choose however you feel appropriate, and let me know if I should take this up again later in case you reject it now.