### PR TITLE
Encode UTF-8 strings to hex escapes in header files

### DIFF
--- a/localize/poconvert.rb
+++ b/localize/poconvert.rb
@@ -783,6 +783,13 @@ msgstr ""
       po_content.items.each do |key, value|
         longest_key = key.length if key.length > longest_key
         value.each_value do |value_inner|
+          value_inner[:string].gsub!(/[^\u0000-\u007e][0-9a-fA-F]?/) do |c|
+            esc = c[0].bytes.map{ |b| '\\x' + b.to_s(16) }.join('')
+            if c[1]
+              esc += '""' + c[1]
+            end
+            esc
+          end
           length = value_inner[:string].length
           longest_value = length if length > longest_value && !value_inner[:string].start_with?("\n")
         end
@@ -868,7 +875,7 @@ msgstr ""
         File.rename(output_file, safe_backup_name(output_file))
       end
       File.open(output_file, 'w') do |f|
-        f.write "\uFEFF" # MSVC requires a BOM.
+        #f.write "\uFEFF" # MSVC requires a BOM.
         f.write(report)
       end
       @@log.info "#{__method__}: Results written to #{output_file}"

--- a/src/language_en_gb.h
+++ b/src/language_en_gb.h
@@ -1,4 +1,4 @@
-﻿#ifndef language_en_gb_h
+#ifndef language_en_gb_h
 #define language_en_gb_h
 /*
  * language_en_gb.h

--- a/src/language_es.h
+++ b/src/language_es.h
@@ -1,4 +1,4 @@
-﻿#ifndef language_es_h
+#ifndef language_es_h
 #define language_es_h
 /*
  * language_es.h
@@ -61,26 +61,26 @@ static languageDefinition language_es = { whichPluralForm_es, {
       - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
       TEXT_GENERAL_INFO_PLEA, 0,        
         "\n"
-        "¿Le gustaría ver Tidy en un español correcto? Por favor considere \n"
-        "ayudarnos a localizar HTML Tidy. Para más detalles consulte \n"
+        "\xc2\xbfLe gustar\xc3\xad""a ver Tidy en un espa\xc3\xb1ol correcto? Por favor considere \n"
+        "ayudarnos a localizar HTML Tidy. Para m\xc3\xa1s detalles consulte \n"
         "https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md \n"
     },
     {/* Please use _only_ <code></code>, <em></em>, <strong></strong>, and <br/>.
 	    It's very important that <br/> be self-closing in this manner! 
         - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
       TidyMakeClean,          0,        
-        "Esta opción especifica si Tidy debe realizar la limpieza de algún legado etiquetas de "
-        "presentación (actualmente <code>&lt;i&gt;</code>, <code>&lt;b&gt;</code>, <code>&lt;center&gt;</"
-        "code> cuando encerrados dentro de las etiquetas apropiadas en línea y <code>&lt;font&gt;</"
-        "code>). Si se establece en <code>yes</code>, entonces etiquetas existentes serán reemplazados "
-        "con CSS <code>&lt;style&gt;</code> y estructural markup según corresponda. "
+        "Esta opci\xc3\xb3n especifica si Tidy debe realizar la limpieza de alg\xc3\xban legado etiquetas de "
+        "presentaci\xc3\xb3n (actualmente <code>&lt;i&gt;</code>, <code>&lt;b&gt;</code>, <code>&lt;center&gt;</"
+        "code> cuando encerrados dentro de las etiquetas apropiadas en l\xc3\xadnea y <code>&lt;font&gt;</"
+        "code>). Si se establece en <code>yes</code>, entonces etiquetas existentes ser\xc3\xa1n reemplazados "
+        "con CSS <code>&lt;style&gt;</code> y estructural markup seg\xc3\xban corresponda. "
     },
 
 #if SUPPORT_ASIAN_ENCODINGS
     {/* Please use _only_ <code></code>, <em></em>, <strong></strong>, and <br/>.
 	    It's very important that <br/> be self-closing in this manner! 
         - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TidyNCR,                0, "Esta opción especifica si Tidy debe permitir referencias de caracteres numéricos. "
+      TidyNCR,                0, "Esta opci\xc3\xb3n especifica si Tidy debe permitir referencias de caracteres num\xc3\xa9ricos. "
     },
 #endif /* SUPPORT_ASIAN_ENCODINGS */
 
@@ -88,22 +88,22 @@ static languageDefinition language_es = { whichPluralForm_es, {
         - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
       TC_TXT_HELP_LANG_1,     0,        
         "\n"
-        "La opción --language (o --lang) indica el lenguaje Tidy debe \n"
+        "La opci\xc3\xb3n --language (o --lang) indica el lenguaje Tidy debe \n"
         "utilizar para comunicar su salida. Tenga en cuenta que esto no es \n"
-        "un servicio de traducción de documentos, y sólo afecta a los mensajes \n"
+        "un servicio de traducci\xc3\xb3n de documentos, y s\xc3\xb3lo afecta a los mensajes \n"
         "que Tidy comunica a usted. \n"
         "\n"
-        "Cuando se utiliza la línea de comandos el argumento --language debe \n"
-        "utilizarse antes de cualquier argumento que dan lugar a la producción, \n"
-        "de lo contrario Tidy producirá la salida antes de que se conozca el \n"
+        "Cuando se utiliza la l\xc3\xadnea de comandos el argumento --language debe \n"
+        "utilizarse antes de cualquier argumento que dan lugar a la producci\xc3\xb3n, \n"
+        "de lo contrario Tidy producir\xc3\xa1 la salida antes de que se conozca el \n"
         "idioma a utilizar. \n"
         "\n"
-        "Además de los códigos de idioma estándar POSIX, Tidy es capaz de \n"
-        "entender códigos de idioma legados de Windows. Tenga en cuenta que \n"
-        "este lista indica los códigos Tidy entiende, y no indica que \n"
-        "actualmente el idioma está instalado. \n"
+        "Adem\xc3\xa1s de los c\xc3\xb3""digos de idioma est\xc3\xa1ndar POSIX, Tidy es capaz de \n"
+        "entender c\xc3\xb3""digos de idioma legados de Windows. Tenga en cuenta que \n"
+        "este lista indica los c\xc3\xb3""digos Tidy entiende, y no indica que \n"
+        "actualmente el idioma est\xc3\xa1 instalado. \n"
         "\n"
-        "La columna más a la derecha indica cómo Tidy comprenderá el \n"
+        "La columna m\xc3\xa1s a la derecha indica c\xc3\xb3mo Tidy comprender\xc3\xa1 el \n"
         "legado nombre de Windows.\n"
         "\n"
     },
@@ -111,23 +111,23 @@ static languageDefinition language_es = { whichPluralForm_es, {
         - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
       TC_TXT_HELP_LANG_2,     0,        
         "\n"
-        "Los siguientes idiomas están instalados actualmente en Tidy. Tenga \n"
-        "en cuenta que no hay garantía de que están completos; sólo quiere decir \n"
-        "que un desarrollador u otro comenzaron a añadir el idioma indicado. \n"
+        "Los siguientes idiomas est\xc3\xa1n instalados actualmente en Tidy. Tenga \n"
+        "en cuenta que no hay garant\xc3\xad""a de que est\xc3\xa1n completos; s\xc3\xb3lo quiere decir \n"
+        "que un desarrollador u otro comenzaron a a\xc3\xb1""adir el idioma indicado. \n"
         "\n"
         "Localizaciones incompletas por defecto se usan \"en\" cuando sea \n"
-        "necesario. ¡Favor de informar los desarrolladores de estes casos! \n"
+        "necesario. \xc2\xa1""Favor de informar los desarrolladores de estes casos! \n"
         "\n"
     },
     {/* This console output should be limited to 78 characters per line.
         - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
       TC_TXT_HELP_LANG_3,     0,        
         "\n"
-        "Si Tidy es capaz de determinar la configuración regional entonces \n"
-        "Tidy utilizará el lenguaje de forma automática de la configuración \n"
+        "Si Tidy es capaz de determinar la configuraci\xc3\xb3n regional entonces \n"
+        "Tidy utilizar\xc3\xa1 el lenguaje de forma autom\xc3\xa1tica de la configuraci\xc3\xb3n \n"
         "regional. Por ejemplo los sistemas de tipo Unix utilizan los variables \n"
-        "$LANG y/o $LC_ALL. Consulte a su documentación del sistema para \n"
-        "obtener más información.\n"
+        "$LANG y/o $LC_ALL. Consulte a su documentaci\xc3\xb3n del sistema para \n"
+        "obtener m\xc3\xa1s informaci\xc3\xb3n.\n"
         "\n"
     },
 

--- a/src/language_es_mx.h
+++ b/src/language_es_mx.h
@@ -1,4 +1,4 @@
-﻿#ifndef language_es_mx_h
+#ifndef language_es_mx_h
 #define language_es_mx_h
 /*
  * language_es_mx.h
@@ -61,8 +61,8 @@ static languageDefinition language_es_mx = { whichPluralForm_es_mx, {
       - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
       TEXT_GENERAL_INFO_PLEA, 0,        
         "\n"
-        "¿Le gustaría ver Tidy en adecuada, español mexicano? Por favor considere \n"
-        "ayudarnos a localizar HTML Tidy. Para más detalles consulte \n"
+        "\xc2\xbfLe gustar\xc3\xad""a ver Tidy en adecuada, espa\xc3\xb1ol mexicano? Por favor considere \n"
+        "ayudarnos a localizar HTML Tidy. Para m\xc3\xa1s detalles consulte \n"
         "https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md \n"
     },
 

--- a/src/language_zh_cn.h
+++ b/src/language_zh_cn.h
@@ -1,4 +1,4 @@
-﻿#ifndef language_zh_cn_h
+#ifndef language_zh_cn_h
 #define language_zh_cn_h
 /*
  * language_zh_cn.h
@@ -57,14 +57,14 @@ static languageDefinition language_zh_cn = { whichPluralForm_zh_cn, {
     {/* Specify the ll or ll_cc language code here. */
       TIDY_LANGUAGE,          0, "zh_cn"
     },
-    { FILE_CANT_OPEN,         0, "无法打开”%1$s”\n"                },
-    { LINE_COLUMN_STRING,     0, "行 %1$d 列 %2$d - "            },
-    { STRING_CONTENT_LOOKS,   0, "文档内容看起来像 %1$s"               },
+    { FILE_CANT_OPEN,         0, "\xe6\x97\xa0\xe6\xb3\x95\xe6\x89\x93\xe5\xbc\x80\xe2\x80\x9d%1$s\xe2\x80\x9d\n"                          },
+    { LINE_COLUMN_STRING,     0, "\xe8\xa1\x8c %1$d \xe5\x88\x97 %2$d - "                                                                  },
+    { STRING_CONTENT_LOOKS,   0, "\xe6\x96\x87\xe6\xa1\xa3\xe5\x86\x85\xe5\xae\xb9\xe7\x9c\x8b\xe8\xb5\xb7\xe6\x9d\xa5\xe5\x83\x8f %1$s"   },
     {/* The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TC_STRING_VERS_A,       0, "HTML Tidy 版本 %2$s 用于 %1$s"
+      TC_STRING_VERS_A,       0, "HTML Tidy \xe7\x89\x88\xe6\x9c\xac %2$s \xe7\x94\xa8\xe4\xba\x8e %1$s"
     },
     {/* The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TC_STRING_VERS_B,       0, "HTML Tidy 版本 %1$s"
+      TC_STRING_VERS_B,       0, "HTML Tidy \xe7\x89\x88\xe6\x9c\xac %1$s"
     },
 
     {/* This MUST be present and last. */


### PR DESCRIPTION
In https://github.com/htacg/tidy-html5/pull/347#issuecomment-175000633 @balthisar wrote:
> * Using hexadecimal escapes doesn't work cross platform given the same source code. Clang on Mac OS X complains about invalid characters. GCC on Windows and Linux produce different results. It's as if each platform is interpreting the hex as its current locale, and that's a non-starter. There's no reason for Tidy to be converting character sets given a perfectly good UTF8 source.

I guess that was most likely because escape sequences of more than two hexadecimal digits were accidentially contained in the sources. This patch here avoids those by appending `""` if the next character could otherwise be misinterpreted as a hexadecimal character.

I must confess that I have been bitten by this as well. I had assumed that more than only up to two hex digits would be included in the codepoint, but found out in [this question on Stack Overflow](http://stackoverflow.com/q/5784969/1468366) that this was not the case, at least according to the standard.