### PR TITLE
Fix skipping parsing character

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2746,14 +2746,9 @@ static Node* GetTokenFromStream( TidyDocImpl* doc, GetTokenMode mode )
                     continue;       /* no text so keep going */
                 }
 
-                /* fix for bug 762102 */
-                if (c == '&')
-                {
-                    TY_(UngetChar)(c, doc->docIn);
-                    --(lexer->lexsize);
-                }
-
                 /* otherwise treat as CDATA */
+                TY_(UngetChar)(c, doc->docIn);
+                lexer->lexsize -= 1;
                 lexer->state = LEX_CONTENT;
                 lexer->waswhite = no;
                 continue;


### PR DESCRIPTION
Hi!
Example:
`<<a href="https://github.com/htacg/tidy-html5">tidy-html5</a>>`
After an unsuccessful attempt to parse `<<`  parsing  continues with `a` character (instead of `<`)

Оutput:
`&lt;&lt;a href="https://github.com/htacg/tidy-html5"&gt;tidy-html5&lt;/a&gt;&gt;`
Instead of:
`&lt;<a href="https://github.com/htacg/tidy-html5">tidy-html5</a>&gt;`