### PR TITLE
Lang help enhance

### DIFF
--- a/console/tidy.c
+++ b/console/tidy.c
@@ -1500,7 +1500,7 @@ static void lang_help( void )
     tidyPrintWindowsLanguageNames("  %-20s -> %s\n");
     printf( "%s", tidyLocalizedString(TC_TXT_HELP_LANG_2) );
     tidyPrintTidyLanguageNames("  %s\n");
-    printf( "%s", tidyLocalizedString(TC_TXT_HELP_LANG_3) );
+    printf( tidyLocalizedString(TC_TXT_HELP_LANG_3), tidyGetLanguage() );
 }
 
 

--- a/localize/poconvert.rb
+++ b/localize/poconvert.rb
@@ -386,7 +386,7 @@ module PoConvertModule
       content.scan(%r!^#if (.*?)#endif!m) do | found_block |
         found_block[0].scan(%r!^\s*\{(?:/\* .*? \*/)?\s*(.*?),\s*.*?,\s*.*?\s*\},?!m) do | item |
           self.items[item[0].to_sym].each_value do  | plural |
-            plural[:if_group] = found_block[0].lines[0].rstrip
+          plural[:if_group] = found_block[0].each_line("\n").to_a[0].rstrip
           end
         end
       end

--- a/localize/poconvert.rb
+++ b/localize/poconvert.rb
@@ -665,7 +665,7 @@ msgstr ""
         if value['0'][:comment]
           value['0'][:comment].each_line { |line| report << "#. #{line.strip}\n"}
         end
-        if %w($u $s $d).any? { | find | value['0'][:string].include?(find) }
+        if %w(%u %s %d).any? { | find | value['0'][:string].include?(find) }
           report << "#, c-format\n"
         end
         report << "msgctxt \"#{key.to_s}\"\n"

--- a/localize/poconvert.rb
+++ b/localize/poconvert.rb
@@ -370,7 +370,7 @@ module PoConvertModule
           line.lstrip.gsub(/\\x(..)/) { |g| [$1.hex].pack('c*').force_encoding('UTF-8') }
         end
         # Eliminate C double-double-quotes.
-        tmp = tmp.join.gsub(/""/) { |g| }
+        tmp = tmp.join.gsub(/(?<!\\)""/) { |g| }
         self.items[l_key][num_case][:string] = tmp
       end
       if !self.items || self.items.empty?

--- a/localize/poconvert.rb
+++ b/localize/poconvert.rb
@@ -408,15 +408,17 @@ module PoConvertModule
 
     attr_accessor :emacs_footer
     attr_accessor :plaintext
+    attr_accessor :force_comments
 
     #########################################################
     # initialize
     #########################################################
     def initialize
-      @po_locale = nil       # The locale to use to generate PO files.
-      @known_locales = {}    # The locales we know about.
-      @emacs_footer = false  # Indicates whether or not to add emacs instructions.
-      @plaintext = false     # Indicates whether or not we should stick to plaintext.
+      @po_locale = nil        # The locale to use to generate PO files.
+      @known_locales = {}     # The locales we know about.
+      @emacs_footer = false   # Indicates whether or not to add emacs instructions.
+      @plaintext = false      # Indicates whether or not we should stick to plaintext.
+      @force_comments = false # Force comments into non-English header files?
     end
 
 
@@ -779,7 +781,7 @@ msgstr ""
       po_content.items.each do |key, value|
         value.each_value do |item_entry|
           item_entry[:if_group] = lang_en.items[key]['0'][:if_group]
-          item_entry[:comment] = lang_en.items[key]['0'][:comment]
+          item_entry[:comment] = force_comments ? lang_en.items[key]['0'][:comment] : nil
         end
       end
 
@@ -1083,6 +1085,10 @@ Complete Help:
            :type => :boolean,
            :desc => 'Specifies that the generated file contain hex escaped characters.',
            :aliases => '-h'
+    option :force_comments,
+           :type =>:boolean,
+           :desc => 'Forces comments into the header file. Base language_en.h always has comments.',
+           :aliases => '-f'
     desc 'msgfmt <input_file.po>', 'Creates a Tidy header H file from the given PO file.'
     long_desc <<-LONG_DESC
       Creates a Tidy header H file from the specified <input_file.po> PO file,
@@ -1104,6 +1110,7 @@ Complete Help:
       args.each do |input_file|
         converter = PoConverter.new
         converter.plaintext = !options[:hex]
+        converter.force_comments = options[:force_comments]
         set_options
         error_count = converter.convert_to_h( input_file, options[:baselang] ) ? error_count : error_count + 1
       end

--- a/localize/translations/language_en_gb.po
+++ b/localize/translations/language_en_gb.po
@@ -5,7 +5,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: HTML Tidy poconvert.rb\n"
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2016-02-17 20:04:18\n"
+"PO-Revision-Date: 2016-03-23 14:49:53\n"
 "Last-Translator: jderry\n"
 "Language-Team: \n"
 
@@ -19,14 +19,17 @@ msgctxt "ATRC_ACCESS_URL"
 msgid "http://www.html-tidy.org/accessibility/"
 msgstr ""
 
+#, c-format
 msgctxt "FILE_CANT_OPEN"
 msgid "Can't open \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "LINE_COLUMN_STRING"
 msgid "line %d column %d - "
 msgstr ""
 
+#, c-format
 msgctxt "STRING_CONTENT_LOOKS"
 msgid "Document content looks like %s"
 msgstr ""
@@ -36,11 +39,13 @@ msgctxt "STRING_DISCARDING"
 msgid "discarding"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_DOCTYPE_GIVEN"
-msgid "Doctype given is \"%s\
+msgid "Doctype given is \"%s\""
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "STRING_ERROR_COUNT"
 msgid "Tidy found %u %s and %u %s!"
 msgstr ""
@@ -66,6 +71,7 @@ msgctxt "STRING_HTML_PROPRIETARY"
 msgid "HTML Proprietary"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_MISSING_MALFORMED"
 msgid "missing or malformed argument for option: %s"
 msgstr ""
@@ -96,10 +102,12 @@ msgctxt "STRING_SPECIFIED"
 msgid "specified"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_FILE"
 msgid "%s: can't open file \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_OPTION"
 msgid "unknown option: %s"
 msgstr ""
@@ -144,6 +152,7 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
+#, c-format
 msgctxt "TEXT_VENDOR_CHARS"
 msgid ""
 "It is unlikely that vendor-specific, system-dependent encodings\n"
@@ -156,6 +165,7 @@ msgstr ""
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TEXT_SGML_CHARS"
 msgid ""
 "Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;\n"
@@ -399,34 +409,42 @@ msgctxt "TidyFatalString"
 msgid "Panic: "
 msgstr ""
 
+#, c-format
 msgctxt "ENCODING_MISMATCH"
 msgid "specified input encoding (%s) does not match actual input encoding (%s)"
 msgstr ""
 
+#, c-format
 msgctxt "VENDOR_SPECIFIC_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_SGML_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF8"
 msgid "%s invalid UTF-8 bytes (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF16"
 msgid "%s invalid UTF-16 surrogate pair (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_NCR"
 msgid "%s invalid numeric character reference %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON"
 msgid "entity \"%s\" doesn't end in ';'"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON_NCR"
 msgid "numeric character reference \"%s\" doesn't end in ';'"
 msgstr ""
@@ -435,142 +453,176 @@ msgctxt "UNESCAPED_AMPERSAND"
 msgid "unescaped & which should be written as &amp;"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ENTITY"
-msgid "unescaped & or unknown entity \"%s\
+msgid "unescaped & or unknown entity \"%s\""
 msgstr ""
 
 msgctxt "APOS_UNDEFINED"
 msgid "named entity &apos; only defined in XML/XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_ATTRIBUTE"
 msgid "%s inserting \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_AUTO_ATTRIBUTE"
-msgid "%s inserting \"%s\" attribute using value \"%s\
+msgid "%s inserting \"%s\" attribute using value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTR_VALUE"
 msgid "%s attribute \"%s\" lacks value"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ATTRIBUTE"
-msgid "%s unknown attribute \"%s\
+msgid "%s unknown attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTRIBUTE"
-msgid "%s proprietary attribute \"%s\
+msgid "%s proprietary attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_ERROR"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_WARN"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "JOINING_ATTRIBUTE"
-msgid "%s joining values of repeated attribute \"%s\
+msgid "%s joining values of repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ATTRIBUTE_VALUE"
-msgid "%s has XML attribute \"%s\
+msgid "%s has XML attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ID_SYNTAX"
 msgid "%s ID \"%s\" uses XML ID syntax"
 msgstr ""
 
+#, c-format
 msgctxt "ATTR_VALUE_NOT_LCASE"
 msgid "%s attribute value \"%s\" must be lower case for XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTR_VALUE"
-msgid "%s proprietary attribute value \"%s\
+msgid "%s proprietary attribute value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "ANCHOR_NOT_UNIQUE"
 msgid "%s anchor \"%s\" already defined"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE"
-msgid "%s attribute \"%s\" has invalid value \"%s\
+msgid "%s attribute \"%s\" has invalid value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE_REPLACED"
 msgid "%s attribute \"%s\" had invalid value \"%s\" and has been replaced"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_ATTRIBUTE"
 msgid "%s attribute name \"%s\" (value=\"%s\") is invalid"
 msgstr ""
 
+#, c-format
 msgctxt "REPEATED_ATTRIBUTE"
-msgid "%s dropping value \"%s\" for repeated attribute \"%s\
+msgid "%s dropping value \"%s\" for repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_XML_ID"
 msgid "%s cannot copy name attribute to id"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_GT"
 msgid "%s missing '>' for end of tag"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_QUOTEMARK"
 msgid "%s unexpected or duplicate quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_QUOTEMARK"
 msgid "%s attribute with missing trailing quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE_ATTR"
 msgid "%s end of file while parsing attributes"
 msgstr ""
 
+#, c-format
 msgctxt "ID_NAME_MISMATCH"
 msgid "%s id and name attribute value mismatch"
 msgstr ""
 
+#, c-format
 msgctxt "BACKSLASH_IN_URI"
 msgid "%s URI reference contains backslash. Typo?"
 msgstr ""
 
+#, c-format
 msgctxt "FIXED_BACKSLASH"
 msgid "%s converting backslash in URI to slash"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_URI_REFERENCE"
 msgid "%s improperly escaped URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "ESCAPED_ILLEGAL_URI"
 msgid "%s escaping malformed URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "NEWLINE_IN_URI"
 msgid "%s discarding newline in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "WHITE_IN_URI"
 msgid "%s discarding whitespace in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_EQUALSIGN"
 msgid "%s unexpected '=', expected attribute name"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_IMAGEMAP"
 msgid "%s should use client-side image map"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTRIBUTE"
 msgid "%s lacks \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "NESTED_EMPHASIS"
 msgid "nested emphasis %s"
 msgstr ""
@@ -579,118 +631,147 @@ msgctxt "NESTED_QUOTATION"
 msgid "nested q elements, possible typo."
 msgstr ""
 
+#, c-format
 msgctxt "OBSOLETE_ELEMENT"
 msgid "replacing obsolete element %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG_WARN"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REMOVED_HTML5"
 msgid "%s element removed from HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_SUMMARY_HTML5"
 msgid "The summary attribute on the %s element is obsolete in HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "TRIM_EMPTY_ELEMENT"
 msgid "trimming empty %s"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_ELEMENT"
 msgid "replacing %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_UNEX_ELEMENT"
 msgid "replacing unexpected %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_FOR"
 msgid "missing </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_BEFORE"
 msgid "missing </%s> before %s"
 msgstr ""
 
+#, c-format
 msgctxt "DISCARDING_UNEXPECTED"
 msgid "discarding unexpected %s"
 msgstr ""
 
+#, c-format
 msgctxt "NON_MATCHING_ENDTAG"
 msgid "replacing unexpected %s with </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TAG_NOT_ALLOWED_IN"
 msgid "%s isn't allowed in <%s> elements"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_STARTTAG"
 msgid "missing <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG"
 msgid "unexpected </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS"
 msgid "too many %s elements"
 msgstr ""
 
+#, c-format
 msgctxt "USING_BR_INPLACE_OF"
 msgid "using <br> in place of %s"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_TAG"
 msgid "inserting implicit <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "CANT_BE_NESTED"
 msgid "%s can't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ELEMENT"
 msgid "%s is not approved by W3C"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_ERROR"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_WARN"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_NESTING"
 msgid "%s shouldn't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "NOFRAMES_CONTENT"
 msgid "%s not inside 'noframes' element"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE"
 msgid "unexpected end of file %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_NOT_EMPTY"
 msgid "%s element not empty or not closed"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG_IN"
 msgid "unexpected </%s> in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS_IN"
 msgid "too many %s elements in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNESCAPED_ELEMENT"
 msgid "unescaped %s in pre content"
 msgstr ""
@@ -759,10 +840,12 @@ msgctxt "DUPLICATE_FRAMESET"
 msgid "repeated FRAMESET element"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ELEMENT"
 msgid "%s is not recognized!"
 msgstr ""
 
+#, c-format
 msgctxt "PREVIOUS_LOCATION"
 msgid "<%s> previously mentioned"
 msgstr ""
@@ -2527,7 +2610,7 @@ msgid ""
 "Can be used to modify behavior of the <code>clean</code> option when set "
 "to <var>yes</var>. "
 "<br/>"
-"If set to <var>yes</var> when <code>clean</code>, "
+"If set to <var>yes</var> when using <code>clean</code>, "
 "<code>&amp;emdash;</code>, <code>&amp;rdquo;</code>, and other named "
 "character entities are downgraded to their closest ASCII equivalents. "
 msgstr ""
@@ -2930,6 +3013,12 @@ msgid ""
 "When set to <var>no</var>, these checks are not performed. "
 msgstr ""
 
+msgctxt "TidyEscapeScripts"
+msgid ""
+"This option causes items that look like closing tags, like <code>&lt;/g</code> to be "
+"escaped to <code>&lt;\\/g</code>. Set this option to 'no' if you do not want this."
+msgstr ""
+
 msgctxt "TC_CAT_DIAGNOSTICS"
 msgid "diagnostics"
 msgstr ""
@@ -2970,6 +3059,7 @@ msgctxt "TC_LABEL_OPT"
 msgid "option"
 msgstr ""
 
+#, c-format
 msgctxt "TC_MAIN_ERROR_LOAD_CONFIG"
 msgid "Loading config file \"%s\" failed, err = %d"
 msgstr ""
@@ -3181,6 +3271,7 @@ msgctxt "TC_STRING_CONF_NOTE"
 msgid "Values marked with an *asterisk are calculated internally by HTML Tidy"
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_OPT_NOT_DOCUMENTED"
 msgid "Warning: option `%s' is not documented."
 msgstr ""
@@ -3189,6 +3280,7 @@ msgctxt "TC_STRING_OUT_OF_MEMORY"
 msgid "Out of memory. Bailing out."
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_FATAL_ERROR"
 msgid "Fatal error: impossible value for id='%d'."
 msgstr ""
@@ -3210,6 +3302,7 @@ msgid "A POSIX or Windows locale must be specified."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_LANG_NOT_FOUND"
 msgid "Tidy doesn't have language '%s,' will use '%s' instead."
 msgstr ""
@@ -3237,11 +3330,13 @@ msgid "HTML Tidy: unknown option."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_A"
 msgid "HTML Tidy for %s version %s"
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_B"
 msgid "HTML Tidy version %s"
 msgstr ""
@@ -3250,6 +3345,7 @@ msgstr ""
 #. - %n represents the name of the executable from the file system, and is mostly like going to be "tidy".
 #. - %2 represents a version number, typically x.x.xx.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_TXT_HELP_1"
 msgid ""
 "\n"
@@ -3262,6 +3358,7 @@ msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
 #. - %s represents the platform, for example, "Mac OS X" or "Windows".
+#, c-format
 msgctxt "TC_TXT_HELP_2A"
 msgid "Command Line Arguments for HTML Tidy for %s:"
 msgstr ""
@@ -3388,6 +3485,8 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#. - The parameter %s is likely to be two to five characters, e.g., en or en_US.
+#, c-format
 msgctxt "TC_TXT_HELP_LANG_3"
 msgid ""
 "\n"
@@ -3395,6 +3494,8 @@ msgid ""
 "locale's language automatically. For example Unix-like systems use a \n"
 "$LANG and/or $LC_ALL environment variable. Consult your operating \n"
 "system documentation for more information. \n"
+"\n"
+"Tidy is currently using locale %s. \n"
 "\n"
 msgstr ""
 

--- a/localize/translations/language_es.po
+++ b/localize/translations/language_es.po
@@ -5,7 +5,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: HTML Tidy poconvert.rb\n"
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2016-02-17 20:04:18\n"
+"PO-Revision-Date: 2016-03-23 14:49:53\n"
 "Last-Translator: jderry\n"
 "Language-Team: \n"
 
@@ -19,14 +19,17 @@ msgctxt "ATRC_ACCESS_URL"
 msgid "http://www.html-tidy.org/accessibility/"
 msgstr ""
 
+#, c-format
 msgctxt "FILE_CANT_OPEN"
 msgid "Can't open \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "LINE_COLUMN_STRING"
 msgid "line %d column %d - "
 msgstr ""
 
+#, c-format
 msgctxt "STRING_CONTENT_LOOKS"
 msgid "Document content looks like %s"
 msgstr ""
@@ -36,11 +39,13 @@ msgctxt "STRING_DISCARDING"
 msgid "discarding"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_DOCTYPE_GIVEN"
-msgid "Doctype given is \"%s\
+msgid "Doctype given is \"%s\""
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "STRING_ERROR_COUNT"
 msgid "Tidy found %u %s and %u %s!"
 msgstr ""
@@ -66,6 +71,7 @@ msgctxt "STRING_HTML_PROPRIETARY"
 msgid "HTML Proprietary"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_MISSING_MALFORMED"
 msgid "missing or malformed argument for option: %s"
 msgstr ""
@@ -96,10 +102,12 @@ msgctxt "STRING_SPECIFIED"
 msgid "specified"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_FILE"
 msgid "%s: can't open file \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_OPTION"
 msgid "unknown option: %s"
 msgstr ""
@@ -144,6 +152,7 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
+#, c-format
 msgctxt "TEXT_VENDOR_CHARS"
 msgid ""
 "It is unlikely that vendor-specific, system-dependent encodings\n"
@@ -156,6 +165,7 @@ msgstr ""
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TEXT_SGML_CHARS"
 msgid ""
 "Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;\n"
@@ -395,34 +405,42 @@ msgctxt "TidyFatalString"
 msgid "Panic: "
 msgstr ""
 
+#, c-format
 msgctxt "ENCODING_MISMATCH"
 msgid "specified input encoding (%s) does not match actual input encoding (%s)"
 msgstr ""
 
+#, c-format
 msgctxt "VENDOR_SPECIFIC_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_SGML_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF8"
 msgid "%s invalid UTF-8 bytes (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF16"
 msgid "%s invalid UTF-16 surrogate pair (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_NCR"
 msgid "%s invalid numeric character reference %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON"
 msgid "entity \"%s\" doesn't end in ';'"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON_NCR"
 msgid "numeric character reference \"%s\" doesn't end in ';'"
 msgstr ""
@@ -431,142 +449,176 @@ msgctxt "UNESCAPED_AMPERSAND"
 msgid "unescaped & which should be written as &amp;"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ENTITY"
-msgid "unescaped & or unknown entity \"%s\
+msgid "unescaped & or unknown entity \"%s\""
 msgstr ""
 
 msgctxt "APOS_UNDEFINED"
 msgid "named entity &apos; only defined in XML/XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_ATTRIBUTE"
 msgid "%s inserting \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_AUTO_ATTRIBUTE"
-msgid "%s inserting \"%s\" attribute using value \"%s\
+msgid "%s inserting \"%s\" attribute using value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTR_VALUE"
 msgid "%s attribute \"%s\" lacks value"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ATTRIBUTE"
-msgid "%s unknown attribute \"%s\
+msgid "%s unknown attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTRIBUTE"
-msgid "%s proprietary attribute \"%s\
+msgid "%s proprietary attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_ERROR"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_WARN"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "JOINING_ATTRIBUTE"
-msgid "%s joining values of repeated attribute \"%s\
+msgid "%s joining values of repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ATTRIBUTE_VALUE"
-msgid "%s has XML attribute \"%s\
+msgid "%s has XML attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ID_SYNTAX"
 msgid "%s ID \"%s\" uses XML ID syntax"
 msgstr ""
 
+#, c-format
 msgctxt "ATTR_VALUE_NOT_LCASE"
 msgid "%s attribute value \"%s\" must be lower case for XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTR_VALUE"
-msgid "%s proprietary attribute value \"%s\
+msgid "%s proprietary attribute value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "ANCHOR_NOT_UNIQUE"
 msgid "%s anchor \"%s\" already defined"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE"
-msgid "%s attribute \"%s\" has invalid value \"%s\
+msgid "%s attribute \"%s\" has invalid value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE_REPLACED"
 msgid "%s attribute \"%s\" had invalid value \"%s\" and has been replaced"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_ATTRIBUTE"
 msgid "%s attribute name \"%s\" (value=\"%s\") is invalid"
 msgstr ""
 
+#, c-format
 msgctxt "REPEATED_ATTRIBUTE"
-msgid "%s dropping value \"%s\" for repeated attribute \"%s\
+msgid "%s dropping value \"%s\" for repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_XML_ID"
 msgid "%s cannot copy name attribute to id"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_GT"
 msgid "%s missing '>' for end of tag"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_QUOTEMARK"
 msgid "%s unexpected or duplicate quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_QUOTEMARK"
 msgid "%s attribute with missing trailing quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE_ATTR"
 msgid "%s end of file while parsing attributes"
 msgstr ""
 
+#, c-format
 msgctxt "ID_NAME_MISMATCH"
 msgid "%s id and name attribute value mismatch"
 msgstr ""
 
+#, c-format
 msgctxt "BACKSLASH_IN_URI"
 msgid "%s URI reference contains backslash. Typo?"
 msgstr ""
 
+#, c-format
 msgctxt "FIXED_BACKSLASH"
 msgid "%s converting backslash in URI to slash"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_URI_REFERENCE"
 msgid "%s improperly escaped URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "ESCAPED_ILLEGAL_URI"
 msgid "%s escaping malformed URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "NEWLINE_IN_URI"
 msgid "%s discarding newline in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "WHITE_IN_URI"
 msgid "%s discarding whitespace in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_EQUALSIGN"
 msgid "%s unexpected '=', expected attribute name"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_IMAGEMAP"
 msgid "%s should use client-side image map"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTRIBUTE"
 msgid "%s lacks \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "NESTED_EMPHASIS"
 msgid "nested emphasis %s"
 msgstr ""
@@ -575,118 +627,147 @@ msgctxt "NESTED_QUOTATION"
 msgid "nested q elements, possible typo."
 msgstr ""
 
+#, c-format
 msgctxt "OBSOLETE_ELEMENT"
 msgid "replacing obsolete element %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG_WARN"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REMOVED_HTML5"
 msgid "%s element removed from HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_SUMMARY_HTML5"
 msgid "The summary attribute on the %s element is obsolete in HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "TRIM_EMPTY_ELEMENT"
 msgid "trimming empty %s"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_ELEMENT"
 msgid "replacing %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_UNEX_ELEMENT"
 msgid "replacing unexpected %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_FOR"
 msgid "missing </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_BEFORE"
 msgid "missing </%s> before %s"
 msgstr ""
 
+#, c-format
 msgctxt "DISCARDING_UNEXPECTED"
 msgid "discarding unexpected %s"
 msgstr ""
 
+#, c-format
 msgctxt "NON_MATCHING_ENDTAG"
 msgid "replacing unexpected %s with </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TAG_NOT_ALLOWED_IN"
 msgid "%s isn't allowed in <%s> elements"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_STARTTAG"
 msgid "missing <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG"
 msgid "unexpected </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS"
 msgid "too many %s elements"
 msgstr ""
 
+#, c-format
 msgctxt "USING_BR_INPLACE_OF"
 msgid "using <br> in place of %s"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_TAG"
 msgid "inserting implicit <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "CANT_BE_NESTED"
 msgid "%s can't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ELEMENT"
 msgid "%s is not approved by W3C"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_ERROR"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_WARN"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_NESTING"
 msgid "%s shouldn't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "NOFRAMES_CONTENT"
 msgid "%s not inside 'noframes' element"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE"
 msgid "unexpected end of file %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_NOT_EMPTY"
 msgid "%s element not empty or not closed"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG_IN"
 msgid "unexpected </%s> in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS_IN"
 msgid "too many %s elements in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNESCAPED_ELEMENT"
 msgid "unescaped %s in pre content"
 msgstr ""
@@ -755,10 +836,12 @@ msgctxt "DUPLICATE_FRAMESET"
 msgid "repeated FRAMESET element"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ELEMENT"
 msgid "%s is not recognized!"
 msgstr ""
 
+#, c-format
 msgctxt "PREVIOUS_LOCATION"
 msgid "<%s> previously mentioned"
 msgstr ""
@@ -2504,7 +2587,7 @@ msgid ""
 "Can be used to modify behavior of the <code>clean</code> option when set "
 "to <var>yes</var>. "
 "<br/>"
-"If set to <var>yes</var> when <code>clean</code>, "
+"If set to <var>yes</var> when using <code>clean</code>, "
 "<code>&amp;emdash;</code>, <code>&amp;rdquo;</code>, and other named "
 "character entities are downgraded to their closest ASCII equivalents. "
 msgstr ""
@@ -2907,6 +2990,12 @@ msgid ""
 "When set to <var>no</var>, these checks are not performed. "
 msgstr ""
 
+msgctxt "TidyEscapeScripts"
+msgid ""
+"This option causes items that look like closing tags, like <code>&lt;/g</code> to be "
+"escaped to <code>&lt;\\/g</code>. Set this option to 'no' if you do not want this."
+msgstr ""
+
 msgctxt "TC_CAT_DIAGNOSTICS"
 msgid "diagnostics"
 msgstr ""
@@ -2947,6 +3036,7 @@ msgctxt "TC_LABEL_OPT"
 msgid "option"
 msgstr ""
 
+#, c-format
 msgctxt "TC_MAIN_ERROR_LOAD_CONFIG"
 msgid "Loading config file \"%s\" failed, err = %d"
 msgstr ""
@@ -3158,6 +3248,7 @@ msgctxt "TC_STRING_CONF_NOTE"
 msgid "Values marked with an *asterisk are calculated internally by HTML Tidy"
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_OPT_NOT_DOCUMENTED"
 msgid "Warning: option `%s' is not documented."
 msgstr ""
@@ -3166,6 +3257,7 @@ msgctxt "TC_STRING_OUT_OF_MEMORY"
 msgid "Out of memory. Bailing out."
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_FATAL_ERROR"
 msgid "Fatal error: impossible value for id='%d'."
 msgstr ""
@@ -3187,6 +3279,7 @@ msgid "A POSIX or Windows locale must be specified."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_LANG_NOT_FOUND"
 msgid "Tidy doesn't have language '%s,' will use '%s' instead."
 msgstr ""
@@ -3214,11 +3307,13 @@ msgid "HTML Tidy: unknown option."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_A"
 msgid "HTML Tidy for %s version %s"
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_B"
 msgid "HTML Tidy version %s"
 msgstr ""
@@ -3227,6 +3322,7 @@ msgstr ""
 #. - %n represents the name of the executable from the file system, and is mostly like going to be "tidy".
 #. - %2 represents a version number, typically x.x.xx.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_TXT_HELP_1"
 msgid ""
 "\n"
@@ -3239,6 +3335,7 @@ msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
 #. - %s represents the platform, for example, "Mac OS X" or "Windows".
+#, c-format
 msgctxt "TC_TXT_HELP_2A"
 msgid "Command Line Arguments for HTML Tidy for %s:"
 msgstr ""
@@ -3367,6 +3464,8 @@ msgstr ""
 "La columna más a la derecha indica cómo Tidy comprenderá el \n"
 "legado nombre de Windows.\n"
 "\n"
+"Tidy está utilizando la configuración regional %s. \n"
+"\n"
 
 #. This console output should be limited to 78 characters per line.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
@@ -3392,6 +3491,8 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#. - The parameter %s is likely to be two to five characters, e.g., en or en_US.
+#, c-format
 msgctxt "TC_TXT_HELP_LANG_3"
 msgid ""
 "\n"
@@ -3399,6 +3500,8 @@ msgid ""
 "locale's language automatically. For example Unix-like systems use a \n"
 "$LANG and/or $LC_ALL environment variable. Consult your operating \n"
 "system documentation for more information. \n"
+"\n"
+"Tidy is currently using locale %s. \n"
 "\n"
 msgstr ""
 "\n"

--- a/localize/translations/language_es.po
+++ b/localize/translations/language_es.po
@@ -3511,4 +3511,6 @@ msgstr ""
 "$LANG y/o $LC_ALL. Consulte a su documentación del sistema para \n"
 "obtener más información.\n"
 "\n"
+"Tidy está utilizando la configuración regional %s. \n"
+"\n"
 

--- a/localize/translations/language_es_mx.po
+++ b/localize/translations/language_es_mx.po
@@ -5,7 +5,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: HTML Tidy poconvert.rb\n"
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2016-02-17 20:04:18\n"
+"PO-Revision-Date: 2016-03-23 14:49:53\n"
 "Last-Translator: jderry\n"
 "Language-Team: \n"
 
@@ -19,14 +19,17 @@ msgctxt "ATRC_ACCESS_URL"
 msgid "http://www.html-tidy.org/accessibility/"
 msgstr ""
 
+#, c-format
 msgctxt "FILE_CANT_OPEN"
 msgid "Can't open \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "LINE_COLUMN_STRING"
 msgid "line %d column %d - "
 msgstr ""
 
+#, c-format
 msgctxt "STRING_CONTENT_LOOKS"
 msgid "Document content looks like %s"
 msgstr ""
@@ -36,11 +39,13 @@ msgctxt "STRING_DISCARDING"
 msgid "discarding"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_DOCTYPE_GIVEN"
-msgid "Doctype given is \"%s\
+msgid "Doctype given is \"%s\""
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "STRING_ERROR_COUNT"
 msgid "Tidy found %u %s and %u %s!"
 msgstr ""
@@ -66,6 +71,7 @@ msgctxt "STRING_HTML_PROPRIETARY"
 msgid "HTML Proprietary"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_MISSING_MALFORMED"
 msgid "missing or malformed argument for option: %s"
 msgstr ""
@@ -96,10 +102,12 @@ msgctxt "STRING_SPECIFIED"
 msgid "specified"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_FILE"
 msgid "%s: can't open file \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_OPTION"
 msgid "unknown option: %s"
 msgstr ""
@@ -144,6 +152,7 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
+#, c-format
 msgctxt "TEXT_VENDOR_CHARS"
 msgid ""
 "It is unlikely that vendor-specific, system-dependent encodings\n"
@@ -156,6 +165,7 @@ msgstr ""
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TEXT_SGML_CHARS"
 msgid ""
 "Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;\n"
@@ -395,34 +405,42 @@ msgctxt "TidyFatalString"
 msgid "Panic: "
 msgstr ""
 
+#, c-format
 msgctxt "ENCODING_MISMATCH"
 msgid "specified input encoding (%s) does not match actual input encoding (%s)"
 msgstr ""
 
+#, c-format
 msgctxt "VENDOR_SPECIFIC_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_SGML_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF8"
 msgid "%s invalid UTF-8 bytes (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF16"
 msgid "%s invalid UTF-16 surrogate pair (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_NCR"
 msgid "%s invalid numeric character reference %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON"
 msgid "entity \"%s\" doesn't end in ';'"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON_NCR"
 msgid "numeric character reference \"%s\" doesn't end in ';'"
 msgstr ""
@@ -431,142 +449,176 @@ msgctxt "UNESCAPED_AMPERSAND"
 msgid "unescaped & which should be written as &amp;"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ENTITY"
-msgid "unescaped & or unknown entity \"%s\
+msgid "unescaped & or unknown entity \"%s\""
 msgstr ""
 
 msgctxt "APOS_UNDEFINED"
 msgid "named entity &apos; only defined in XML/XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_ATTRIBUTE"
 msgid "%s inserting \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_AUTO_ATTRIBUTE"
-msgid "%s inserting \"%s\" attribute using value \"%s\
+msgid "%s inserting \"%s\" attribute using value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTR_VALUE"
 msgid "%s attribute \"%s\" lacks value"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ATTRIBUTE"
-msgid "%s unknown attribute \"%s\
+msgid "%s unknown attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTRIBUTE"
-msgid "%s proprietary attribute \"%s\
+msgid "%s proprietary attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_ERROR"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_WARN"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "JOINING_ATTRIBUTE"
-msgid "%s joining values of repeated attribute \"%s\
+msgid "%s joining values of repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ATTRIBUTE_VALUE"
-msgid "%s has XML attribute \"%s\
+msgid "%s has XML attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ID_SYNTAX"
 msgid "%s ID \"%s\" uses XML ID syntax"
 msgstr ""
 
+#, c-format
 msgctxt "ATTR_VALUE_NOT_LCASE"
 msgid "%s attribute value \"%s\" must be lower case for XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTR_VALUE"
-msgid "%s proprietary attribute value \"%s\
+msgid "%s proprietary attribute value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "ANCHOR_NOT_UNIQUE"
 msgid "%s anchor \"%s\" already defined"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE"
-msgid "%s attribute \"%s\" has invalid value \"%s\
+msgid "%s attribute \"%s\" has invalid value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE_REPLACED"
 msgid "%s attribute \"%s\" had invalid value \"%s\" and has been replaced"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_ATTRIBUTE"
 msgid "%s attribute name \"%s\" (value=\"%s\") is invalid"
 msgstr ""
 
+#, c-format
 msgctxt "REPEATED_ATTRIBUTE"
-msgid "%s dropping value \"%s\" for repeated attribute \"%s\
+msgid "%s dropping value \"%s\" for repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_XML_ID"
 msgid "%s cannot copy name attribute to id"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_GT"
 msgid "%s missing '>' for end of tag"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_QUOTEMARK"
 msgid "%s unexpected or duplicate quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_QUOTEMARK"
 msgid "%s attribute with missing trailing quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE_ATTR"
 msgid "%s end of file while parsing attributes"
 msgstr ""
 
+#, c-format
 msgctxt "ID_NAME_MISMATCH"
 msgid "%s id and name attribute value mismatch"
 msgstr ""
 
+#, c-format
 msgctxt "BACKSLASH_IN_URI"
 msgid "%s URI reference contains backslash. Typo?"
 msgstr ""
 
+#, c-format
 msgctxt "FIXED_BACKSLASH"
 msgid "%s converting backslash in URI to slash"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_URI_REFERENCE"
 msgid "%s improperly escaped URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "ESCAPED_ILLEGAL_URI"
 msgid "%s escaping malformed URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "NEWLINE_IN_URI"
 msgid "%s discarding newline in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "WHITE_IN_URI"
 msgid "%s discarding whitespace in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_EQUALSIGN"
 msgid "%s unexpected '=', expected attribute name"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_IMAGEMAP"
 msgid "%s should use client-side image map"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTRIBUTE"
 msgid "%s lacks \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "NESTED_EMPHASIS"
 msgid "nested emphasis %s"
 msgstr ""
@@ -575,118 +627,147 @@ msgctxt "NESTED_QUOTATION"
 msgid "nested q elements, possible typo."
 msgstr ""
 
+#, c-format
 msgctxt "OBSOLETE_ELEMENT"
 msgid "replacing obsolete element %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG_WARN"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REMOVED_HTML5"
 msgid "%s element removed from HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_SUMMARY_HTML5"
 msgid "The summary attribute on the %s element is obsolete in HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "TRIM_EMPTY_ELEMENT"
 msgid "trimming empty %s"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_ELEMENT"
 msgid "replacing %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_UNEX_ELEMENT"
 msgid "replacing unexpected %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_FOR"
 msgid "missing </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_BEFORE"
 msgid "missing </%s> before %s"
 msgstr ""
 
+#, c-format
 msgctxt "DISCARDING_UNEXPECTED"
 msgid "discarding unexpected %s"
 msgstr ""
 
+#, c-format
 msgctxt "NON_MATCHING_ENDTAG"
 msgid "replacing unexpected %s with </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TAG_NOT_ALLOWED_IN"
 msgid "%s isn't allowed in <%s> elements"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_STARTTAG"
 msgid "missing <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG"
 msgid "unexpected </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS"
 msgid "too many %s elements"
 msgstr ""
 
+#, c-format
 msgctxt "USING_BR_INPLACE_OF"
 msgid "using <br> in place of %s"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_TAG"
 msgid "inserting implicit <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "CANT_BE_NESTED"
 msgid "%s can't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ELEMENT"
 msgid "%s is not approved by W3C"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_ERROR"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_WARN"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_NESTING"
 msgid "%s shouldn't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "NOFRAMES_CONTENT"
 msgid "%s not inside 'noframes' element"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE"
 msgid "unexpected end of file %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_NOT_EMPTY"
 msgid "%s element not empty or not closed"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG_IN"
 msgid "unexpected </%s> in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS_IN"
 msgid "too many %s elements in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNESCAPED_ELEMENT"
 msgid "unescaped %s in pre content"
 msgstr ""
@@ -755,10 +836,12 @@ msgctxt "DUPLICATE_FRAMESET"
 msgid "repeated FRAMESET element"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ELEMENT"
 msgid "%s is not recognized!"
 msgstr ""
 
+#, c-format
 msgctxt "PREVIOUS_LOCATION"
 msgid "<%s> previously mentioned"
 msgstr ""
@@ -2499,7 +2582,7 @@ msgid ""
 "Can be used to modify behavior of the <code>clean</code> option when set "
 "to <var>yes</var>. "
 "<br/>"
-"If set to <var>yes</var> when <code>clean</code>, "
+"If set to <var>yes</var> when using <code>clean</code>, "
 "<code>&amp;emdash;</code>, <code>&amp;rdquo;</code>, and other named "
 "character entities are downgraded to their closest ASCII equivalents. "
 msgstr ""
@@ -2902,6 +2985,12 @@ msgid ""
 "When set to <var>no</var>, these checks are not performed. "
 msgstr ""
 
+msgctxt "TidyEscapeScripts"
+msgid ""
+"This option causes items that look like closing tags, like <code>&lt;/g</code> to be "
+"escaped to <code>&lt;\\/g</code>. Set this option to 'no' if you do not want this."
+msgstr ""
+
 msgctxt "TC_CAT_DIAGNOSTICS"
 msgid "diagnostics"
 msgstr ""
@@ -2942,6 +3031,7 @@ msgctxt "TC_LABEL_OPT"
 msgid "option"
 msgstr ""
 
+#, c-format
 msgctxt "TC_MAIN_ERROR_LOAD_CONFIG"
 msgid "Loading config file \"%s\" failed, err = %d"
 msgstr ""
@@ -3153,6 +3243,7 @@ msgctxt "TC_STRING_CONF_NOTE"
 msgid "Values marked with an *asterisk are calculated internally by HTML Tidy"
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_OPT_NOT_DOCUMENTED"
 msgid "Warning: option `%s' is not documented."
 msgstr ""
@@ -3161,6 +3252,7 @@ msgctxt "TC_STRING_OUT_OF_MEMORY"
 msgid "Out of memory. Bailing out."
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_FATAL_ERROR"
 msgid "Fatal error: impossible value for id='%d'."
 msgstr ""
@@ -3182,6 +3274,7 @@ msgid "A POSIX or Windows locale must be specified."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_LANG_NOT_FOUND"
 msgid "Tidy doesn't have language '%s,' will use '%s' instead."
 msgstr ""
@@ -3209,11 +3302,13 @@ msgid "HTML Tidy: unknown option."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_A"
 msgid "HTML Tidy for %s version %s"
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_B"
 msgid "HTML Tidy version %s"
 msgstr ""
@@ -3222,6 +3317,7 @@ msgstr ""
 #. - %n represents the name of the executable from the file system, and is mostly like going to be "tidy".
 #. - %2 represents a version number, typically x.x.xx.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_TXT_HELP_1"
 msgid ""
 "\n"
@@ -3234,6 +3330,7 @@ msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
 #. - %s represents the platform, for example, "Mac OS X" or "Windows".
+#, c-format
 msgctxt "TC_TXT_HELP_2A"
 msgid "Command Line Arguments for HTML Tidy for %s:"
 msgstr ""
@@ -3360,6 +3457,8 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#. - The parameter %s is likely to be two to five characters, e.g., en or en_US.
+#, c-format
 msgctxt "TC_TXT_HELP_LANG_3"
 msgid ""
 "\n"
@@ -3367,6 +3466,8 @@ msgid ""
 "locale's language automatically. For example Unix-like systems use a \n"
 "$LANG and/or $LC_ALL environment variable. Consult your operating \n"
 "system documentation for more information. \n"
+"\n"
+"Tidy is currently using locale %s. \n"
 "\n"
 msgstr ""
 

--- a/localize/translations/language_zh_cn.po
+++ b/localize/translations/language_zh_cn.po
@@ -5,7 +5,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: HTML Tidy poconvert.rb\n"
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2016-02-17 20:04:18\n"
+"PO-Revision-Date: 2016-03-23 14:49:53\n"
 "Last-Translator: jderry\n"
 "Language-Team: \n"
 
@@ -19,14 +19,17 @@ msgctxt "ATRC_ACCESS_URL"
 msgid "http://www.html-tidy.org/accessibility/"
 msgstr ""
 
+#, c-format
 msgctxt "FILE_CANT_OPEN"
 msgid "Can't open \"%s\"\n"
 msgstr "无法打开”%s”\n"
 
+#, c-format
 msgctxt "LINE_COLUMN_STRING"
 msgid "line %d column %d - "
 msgstr "行 %d 列 %d - "
 
+#, c-format
 msgctxt "STRING_CONTENT_LOOKS"
 msgid "Document content looks like %s"
 msgstr "文档内容看起来像 %s"
@@ -36,11 +39,13 @@ msgctxt "STRING_DISCARDING"
 msgid "discarding"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_DOCTYPE_GIVEN"
-msgid "Doctype given is \"%s\
+msgid "Doctype given is \"%s\""
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "STRING_ERROR_COUNT"
 msgid "Tidy found %u %s and %u %s!"
 msgstr ""
@@ -64,6 +69,7 @@ msgctxt "STRING_HTML_PROPRIETARY"
 msgid "HTML Proprietary"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_MISSING_MALFORMED"
 msgid "missing or malformed argument for option: %s"
 msgstr ""
@@ -94,10 +100,12 @@ msgctxt "STRING_SPECIFIED"
 msgid "specified"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_FILE"
 msgid "%s: can't open file \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_OPTION"
 msgid "unknown option: %s"
 msgstr ""
@@ -142,6 +150,7 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
+#, c-format
 msgctxt "TEXT_VENDOR_CHARS"
 msgid ""
 "It is unlikely that vendor-specific, system-dependent encodings\n"
@@ -154,6 +163,7 @@ msgstr ""
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TEXT_SGML_CHARS"
 msgid ""
 "Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;\n"
@@ -389,34 +399,42 @@ msgctxt "TidyFatalString"
 msgid "Panic: "
 msgstr ""
 
+#, c-format
 msgctxt "ENCODING_MISMATCH"
 msgid "specified input encoding (%s) does not match actual input encoding (%s)"
 msgstr ""
 
+#, c-format
 msgctxt "VENDOR_SPECIFIC_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_SGML_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF8"
 msgid "%s invalid UTF-8 bytes (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF16"
 msgid "%s invalid UTF-16 surrogate pair (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_NCR"
 msgid "%s invalid numeric character reference %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON"
 msgid "entity \"%s\" doesn't end in ';'"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON_NCR"
 msgid "numeric character reference \"%s\" doesn't end in ';'"
 msgstr ""
@@ -425,142 +443,176 @@ msgctxt "UNESCAPED_AMPERSAND"
 msgid "unescaped & which should be written as &amp;"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ENTITY"
-msgid "unescaped & or unknown entity \"%s\
+msgid "unescaped & or unknown entity \"%s\""
 msgstr ""
 
 msgctxt "APOS_UNDEFINED"
 msgid "named entity &apos; only defined in XML/XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_ATTRIBUTE"
 msgid "%s inserting \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_AUTO_ATTRIBUTE"
-msgid "%s inserting \"%s\" attribute using value \"%s\
+msgid "%s inserting \"%s\" attribute using value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTR_VALUE"
 msgid "%s attribute \"%s\" lacks value"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ATTRIBUTE"
-msgid "%s unknown attribute \"%s\
+msgid "%s unknown attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTRIBUTE"
-msgid "%s proprietary attribute \"%s\
+msgid "%s proprietary attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_ERROR"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_WARN"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "JOINING_ATTRIBUTE"
-msgid "%s joining values of repeated attribute \"%s\
+msgid "%s joining values of repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ATTRIBUTE_VALUE"
-msgid "%s has XML attribute \"%s\
+msgid "%s has XML attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ID_SYNTAX"
 msgid "%s ID \"%s\" uses XML ID syntax"
 msgstr ""
 
+#, c-format
 msgctxt "ATTR_VALUE_NOT_LCASE"
 msgid "%s attribute value \"%s\" must be lower case for XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTR_VALUE"
-msgid "%s proprietary attribute value \"%s\
+msgid "%s proprietary attribute value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "ANCHOR_NOT_UNIQUE"
 msgid "%s anchor \"%s\" already defined"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE"
-msgid "%s attribute \"%s\" has invalid value \"%s\
+msgid "%s attribute \"%s\" has invalid value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE_REPLACED"
 msgid "%s attribute \"%s\" had invalid value \"%s\" and has been replaced"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_ATTRIBUTE"
 msgid "%s attribute name \"%s\" (value=\"%s\") is invalid"
 msgstr ""
 
+#, c-format
 msgctxt "REPEATED_ATTRIBUTE"
-msgid "%s dropping value \"%s\" for repeated attribute \"%s\
+msgid "%s dropping value \"%s\" for repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_XML_ID"
 msgid "%s cannot copy name attribute to id"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_GT"
 msgid "%s missing '>' for end of tag"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_QUOTEMARK"
 msgid "%s unexpected or duplicate quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_QUOTEMARK"
 msgid "%s attribute with missing trailing quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE_ATTR"
 msgid "%s end of file while parsing attributes"
 msgstr ""
 
+#, c-format
 msgctxt "ID_NAME_MISMATCH"
 msgid "%s id and name attribute value mismatch"
 msgstr ""
 
+#, c-format
 msgctxt "BACKSLASH_IN_URI"
 msgid "%s URI reference contains backslash. Typo?"
 msgstr ""
 
+#, c-format
 msgctxt "FIXED_BACKSLASH"
 msgid "%s converting backslash in URI to slash"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_URI_REFERENCE"
 msgid "%s improperly escaped URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "ESCAPED_ILLEGAL_URI"
 msgid "%s escaping malformed URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "NEWLINE_IN_URI"
 msgid "%s discarding newline in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "WHITE_IN_URI"
 msgid "%s discarding whitespace in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_EQUALSIGN"
 msgid "%s unexpected '=', expected attribute name"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_IMAGEMAP"
 msgid "%s should use client-side image map"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTRIBUTE"
 msgid "%s lacks \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "NESTED_EMPHASIS"
 msgid "nested emphasis %s"
 msgstr ""
@@ -569,118 +621,147 @@ msgctxt "NESTED_QUOTATION"
 msgid "nested q elements, possible typo."
 msgstr ""
 
+#, c-format
 msgctxt "OBSOLETE_ELEMENT"
 msgid "replacing obsolete element %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG_WARN"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REMOVED_HTML5"
 msgid "%s element removed from HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_SUMMARY_HTML5"
 msgid "The summary attribute on the %s element is obsolete in HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "TRIM_EMPTY_ELEMENT"
 msgid "trimming empty %s"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_ELEMENT"
 msgid "replacing %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_UNEX_ELEMENT"
 msgid "replacing unexpected %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_FOR"
 msgid "missing </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_BEFORE"
 msgid "missing </%s> before %s"
 msgstr ""
 
+#, c-format
 msgctxt "DISCARDING_UNEXPECTED"
 msgid "discarding unexpected %s"
 msgstr ""
 
+#, c-format
 msgctxt "NON_MATCHING_ENDTAG"
 msgid "replacing unexpected %s with </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TAG_NOT_ALLOWED_IN"
 msgid "%s isn't allowed in <%s> elements"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_STARTTAG"
 msgid "missing <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG"
 msgid "unexpected </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS"
 msgid "too many %s elements"
 msgstr ""
 
+#, c-format
 msgctxt "USING_BR_INPLACE_OF"
 msgid "using <br> in place of %s"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_TAG"
 msgid "inserting implicit <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "CANT_BE_NESTED"
 msgid "%s can't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ELEMENT"
 msgid "%s is not approved by W3C"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_ERROR"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_WARN"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_NESTING"
 msgid "%s shouldn't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "NOFRAMES_CONTENT"
 msgid "%s not inside 'noframes' element"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE"
 msgid "unexpected end of file %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_NOT_EMPTY"
 msgid "%s element not empty or not closed"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG_IN"
 msgid "unexpected </%s> in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS_IN"
 msgid "too many %s elements in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNESCAPED_ELEMENT"
 msgid "unescaped %s in pre content"
 msgstr ""
@@ -749,10 +830,12 @@ msgctxt "DUPLICATE_FRAMESET"
 msgid "repeated FRAMESET element"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ELEMENT"
 msgid "%s is not recognized!"
 msgstr ""
 
+#, c-format
 msgctxt "PREVIOUS_LOCATION"
 msgid "<%s> previously mentioned"
 msgstr ""
@@ -2493,7 +2576,7 @@ msgid ""
 "Can be used to modify behavior of the <code>clean</code> option when set "
 "to <var>yes</var>. "
 "<br/>"
-"If set to <var>yes</var> when <code>clean</code>, "
+"If set to <var>yes</var> when using <code>clean</code>, "
 "<code>&amp;emdash;</code>, <code>&amp;rdquo;</code>, and other named "
 "character entities are downgraded to their closest ASCII equivalents. "
 msgstr ""
@@ -2896,6 +2979,12 @@ msgid ""
 "When set to <var>no</var>, these checks are not performed. "
 msgstr ""
 
+msgctxt "TidyEscapeScripts"
+msgid ""
+"This option causes items that look like closing tags, like <code>&lt;/g</code> to be "
+"escaped to <code>&lt;\\/g</code>. Set this option to 'no' if you do not want this."
+msgstr ""
+
 msgctxt "TC_CAT_DIAGNOSTICS"
 msgid "diagnostics"
 msgstr ""
@@ -2936,6 +3025,7 @@ msgctxt "TC_LABEL_OPT"
 msgid "option"
 msgstr ""
 
+#, c-format
 msgctxt "TC_MAIN_ERROR_LOAD_CONFIG"
 msgid "Loading config file \"%s\" failed, err = %d"
 msgstr ""
@@ -3147,6 +3237,7 @@ msgctxt "TC_STRING_CONF_NOTE"
 msgid "Values marked with an *asterisk are calculated internally by HTML Tidy"
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_OPT_NOT_DOCUMENTED"
 msgid "Warning: option `%s' is not documented."
 msgstr ""
@@ -3155,6 +3246,7 @@ msgctxt "TC_STRING_OUT_OF_MEMORY"
 msgid "Out of memory. Bailing out."
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_FATAL_ERROR"
 msgid "Fatal error: impossible value for id='%d'."
 msgstr ""
@@ -3176,6 +3268,7 @@ msgid "A POSIX or Windows locale must be specified."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_LANG_NOT_FOUND"
 msgid "Tidy doesn't have language '%s,' will use '%s' instead."
 msgstr ""
@@ -3203,11 +3296,13 @@ msgid "HTML Tidy: unknown option."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_A"
 msgid "HTML Tidy for %s version %s"
 msgstr "HTML Tidy 用于 %s 版本 %s"
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_B"
 msgid "HTML Tidy version %s"
 msgstr "HTML Tidy 版本 %s"
@@ -3216,6 +3311,7 @@ msgstr "HTML Tidy 版本 %s"
 #. - %n represents the name of the executable from the file system, and is mostly like going to be "tidy".
 #. - %2 represents a version number, typically x.x.xx.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_TXT_HELP_1"
 msgid ""
 "\n"
@@ -3228,6 +3324,7 @@ msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
 #. - %s represents the platform, for example, "Mac OS X" or "Windows".
+#, c-format
 msgctxt "TC_TXT_HELP_2A"
 msgid "Command Line Arguments for HTML Tidy for %s:"
 msgstr ""
@@ -3354,6 +3451,8 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#. - The parameter %s is likely to be two to five characters, e.g., en or en_US.
+#, c-format
 msgctxt "TC_TXT_HELP_LANG_3"
 msgid ""
 "\n"
@@ -3361,6 +3460,8 @@ msgid ""
 "locale's language automatically. For example Unix-like systems use a \n"
 "$LANG and/or $LC_ALL environment variable. Consult your operating \n"
 "system documentation for more information. \n"
+"\n"
+"Tidy is currently using locale %s. \n"
 "\n"
 msgstr ""
 

--- a/localize/translations/tidy.pot
+++ b/localize/translations/tidy.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: HTML Tidy poconvert.rb\n"
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2016-02-17 20:03:12\n"
+"POT-Creation-Date: 2016-03-23 14:47:28\n"
 "Last-Translator: jderry\n"
 "Language-Team: \n"
 
@@ -19,14 +19,17 @@ msgctxt "ATRC_ACCESS_URL"
 msgid "http://www.html-tidy.org/accessibility/"
 msgstr ""
 
+#, c-format
 msgctxt "FILE_CANT_OPEN"
 msgid "Can't open \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "LINE_COLUMN_STRING"
 msgid "line %d column %d - "
 msgstr ""
 
+#, c-format
 msgctxt "STRING_CONTENT_LOOKS"
 msgid "Document content looks like %s"
 msgstr ""
@@ -36,11 +39,13 @@ msgctxt "STRING_DISCARDING"
 msgid "discarding"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_DOCTYPE_GIVEN"
-msgid "Doctype given is \"%s\
+msgid "Doctype given is \"%s\""
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "STRING_ERROR_COUNT"
 msgid "Tidy found %u %s and %u %s!"
 msgstr ""
@@ -66,6 +71,7 @@ msgctxt "STRING_HTML_PROPRIETARY"
 msgid "HTML Proprietary"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_MISSING_MALFORMED"
 msgid "missing or malformed argument for option: %s"
 msgstr ""
@@ -96,10 +102,12 @@ msgctxt "STRING_SPECIFIED"
 msgid "specified"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_FILE"
 msgid "%s: can't open file \"%s\"\n"
 msgstr ""
 
+#, c-format
 msgctxt "STRING_UNKNOWN_OPTION"
 msgid "unknown option: %s"
 msgstr ""
@@ -144,6 +152,7 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
+#, c-format
 msgctxt "TEXT_VENDOR_CHARS"
 msgid ""
 "It is unlikely that vendor-specific, system-dependent encodings\n"
@@ -156,6 +165,7 @@ msgstr ""
 #. This console output should be limited to 78 characters per line.
 #. - %s represents a string-encoding name which may be localized in your language.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TEXT_SGML_CHARS"
 msgid ""
 "Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;\n"
@@ -391,34 +401,42 @@ msgctxt "TidyFatalString"
 msgid "Panic: "
 msgstr ""
 
+#, c-format
 msgctxt "ENCODING_MISMATCH"
 msgid "specified input encoding (%s) does not match actual input encoding (%s)"
 msgstr ""
 
+#, c-format
 msgctxt "VENDOR_SPECIFIC_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_SGML_CHARS"
 msgid "%s invalid character code %s"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF8"
 msgid "%s invalid UTF-8 bytes (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_UTF16"
 msgid "%s invalid UTF-16 surrogate pair (char. code %s)"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_NCR"
 msgid "%s invalid numeric character reference %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON"
 msgid "entity \"%s\" doesn't end in ';'"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_SEMICOLON_NCR"
 msgid "numeric character reference \"%s\" doesn't end in ';'"
 msgstr ""
@@ -427,142 +445,176 @@ msgctxt "UNESCAPED_AMPERSAND"
 msgid "unescaped & which should be written as &amp;"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ENTITY"
-msgid "unescaped & or unknown entity \"%s\
+msgid "unescaped & or unknown entity \"%s\""
 msgstr ""
 
 msgctxt "APOS_UNDEFINED"
 msgid "named entity &apos; only defined in XML/XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_ATTRIBUTE"
 msgid "%s inserting \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_AUTO_ATTRIBUTE"
-msgid "%s inserting \"%s\" attribute using value \"%s\
+msgid "%s inserting \"%s\" attribute using value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTR_VALUE"
 msgid "%s attribute \"%s\" lacks value"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ATTRIBUTE"
-msgid "%s unknown attribute \"%s\
+msgid "%s unknown attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTRIBUTE"
-msgid "%s proprietary attribute \"%s\
+msgid "%s proprietary attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_ERROR"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISMATCHED_ATTRIBUTE_WARN"
 msgid "%s attribute \"%s\" not allowed for %s"
 msgstr ""
 
+#, c-format
 msgctxt "JOINING_ATTRIBUTE"
-msgid "%s joining values of repeated attribute \"%s\
+msgid "%s joining values of repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ATTRIBUTE_VALUE"
-msgid "%s has XML attribute \"%s\
+msgid "%s has XML attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "XML_ID_SYNTAX"
 msgid "%s ID \"%s\" uses XML ID syntax"
 msgstr ""
 
+#, c-format
 msgctxt "ATTR_VALUE_NOT_LCASE"
 msgid "%s attribute value \"%s\" must be lower case for XHTML"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ATTR_VALUE"
-msgid "%s proprietary attribute value \"%s\
+msgid "%s proprietary attribute value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "ANCHOR_NOT_UNIQUE"
 msgid "%s anchor \"%s\" already defined"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE"
-msgid "%s attribute \"%s\" has invalid value \"%s\
+msgid "%s attribute \"%s\" has invalid value \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "BAD_ATTRIBUTE_VALUE_REPLACED"
 msgid "%s attribute \"%s\" had invalid value \"%s\" and has been replaced"
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_ATTRIBUTE"
 msgid "%s attribute name \"%s\" (value=\"%s\") is invalid"
 msgstr ""
 
+#, c-format
 msgctxt "REPEATED_ATTRIBUTE"
-msgid "%s dropping value \"%s\" for repeated attribute \"%s\
+msgid "%s dropping value \"%s\" for repeated attribute \"%s\""
 msgstr ""
 
+#, c-format
 msgctxt "INVALID_XML_ID"
 msgid "%s cannot copy name attribute to id"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_GT"
 msgid "%s missing '>' for end of tag"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_QUOTEMARK"
 msgid "%s unexpected or duplicate quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_QUOTEMARK"
 msgid "%s attribute with missing trailing quote mark"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE_ATTR"
 msgid "%s end of file while parsing attributes"
 msgstr ""
 
+#, c-format
 msgctxt "ID_NAME_MISMATCH"
 msgid "%s id and name attribute value mismatch"
 msgstr ""
 
+#, c-format
 msgctxt "BACKSLASH_IN_URI"
 msgid "%s URI reference contains backslash. Typo?"
 msgstr ""
 
+#, c-format
 msgctxt "FIXED_BACKSLASH"
 msgid "%s converting backslash in URI to slash"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_URI_REFERENCE"
 msgid "%s improperly escaped URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "ESCAPED_ILLEGAL_URI"
 msgid "%s escaping malformed URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "NEWLINE_IN_URI"
 msgid "%s discarding newline in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "WHITE_IN_URI"
 msgid "%s discarding whitespace in URI reference"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_EQUALSIGN"
 msgid "%s unexpected '=', expected attribute name"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_IMAGEMAP"
 msgid "%s should use client-side image map"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ATTRIBUTE"
 msgid "%s lacks \"%s\" attribute"
 msgstr ""
 
+#, c-format
 msgctxt "NESTED_EMPHASIS"
 msgid "nested emphasis %s"
 msgstr ""
@@ -571,118 +623,147 @@ msgctxt "NESTED_QUOTATION"
 msgid "nested q elements, possible typo."
 msgstr ""
 
+#, c-format
 msgctxt "OBSOLETE_ELEMENT"
 msgid "replacing obsolete element %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG_WARN"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REMOVED_HTML5"
 msgid "%s element removed from HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "BAD_SUMMARY_HTML5"
 msgid "The summary attribute on the %s element is obsolete in HTML5"
 msgstr ""
 
+#, c-format
 msgctxt "TRIM_EMPTY_ELEMENT"
 msgid "trimming empty %s"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_ELEMENT"
 msgid "replacing %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "COERCE_TO_ENDTAG"
 msgid "<%s> is probably intended as </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "REPLACING_UNEX_ELEMENT"
 msgid "replacing unexpected %s with %s"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_FOR"
 msgid "missing </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_ENDTAG_BEFORE"
 msgid "missing </%s> before %s"
 msgstr ""
 
+#, c-format
 msgctxt "DISCARDING_UNEXPECTED"
 msgid "discarding unexpected %s"
 msgstr ""
 
+#, c-format
 msgctxt "NON_MATCHING_ENDTAG"
 msgid "replacing unexpected %s with </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TAG_NOT_ALLOWED_IN"
 msgid "%s isn't allowed in <%s> elements"
 msgstr ""
 
+#, c-format
 msgctxt "MISSING_STARTTAG"
 msgid "missing <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG"
 msgid "unexpected </%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS"
 msgid "too many %s elements"
 msgstr ""
 
+#, c-format
 msgctxt "USING_BR_INPLACE_OF"
 msgid "using <br> in place of %s"
 msgstr ""
 
+#, c-format
 msgctxt "INSERTING_TAG"
 msgid "inserting implicit <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "CANT_BE_NESTED"
 msgid "%s can't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "PROPRIETARY_ELEMENT"
 msgid "%s is not approved by W3C"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_ERROR"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_VERS_MISMATCH_WARN"
 msgid "%s element not available in %s"
 msgstr ""
 
+#, c-format
 msgctxt "ILLEGAL_NESTING"
 msgid "%s shouldn't be nested"
 msgstr ""
 
+#, c-format
 msgctxt "NOFRAMES_CONTENT"
 msgid "%s not inside 'noframes' element"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_END_OF_FILE"
 msgid "unexpected end of file %s"
 msgstr ""
 
+#, c-format
 msgctxt "ELEMENT_NOT_EMPTY"
 msgid "%s element not empty or not closed"
 msgstr ""
 
+#, c-format
 msgctxt "UNEXPECTED_ENDTAG_IN"
 msgid "unexpected </%s> in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "TOO_MANY_ELEMENTS_IN"
 msgid "too many %s elements in <%s>"
 msgstr ""
 
+#, c-format
 msgctxt "UNESCAPED_ELEMENT"
 msgid "unescaped %s in pre content"
 msgstr ""
@@ -751,10 +832,12 @@ msgctxt "DUPLICATE_FRAMESET"
 msgid "repeated FRAMESET element"
 msgstr ""
 
+#, c-format
 msgctxt "UNKNOWN_ELEMENT"
 msgid "%s is not recognized!"
 msgstr ""
 
+#, c-format
 msgctxt "PREVIOUS_LOCATION"
 msgid "<%s> previously mentioned"
 msgstr ""
@@ -2495,7 +2578,7 @@ msgid ""
 "Can be used to modify behavior of the <code>clean</code> option when set "
 "to <var>yes</var>. "
 "<br/>"
-"If set to <var>yes</var> when <code>clean</code>, "
+"If set to <var>yes</var> when using <code>clean</code>, "
 "<code>&amp;emdash;</code>, <code>&amp;rdquo;</code>, and other named "
 "character entities are downgraded to their closest ASCII equivalents. "
 msgstr ""
@@ -2898,6 +2981,12 @@ msgid ""
 "When set to <var>no</var>, these checks are not performed. "
 msgstr ""
 
+msgctxt "TidyEscapeScripts"
+msgid ""
+"This option causes items that look like closing tags, like <code>&lt;/g</code> to be "
+"escaped to <code>&lt;\\/g</code>. Set this option to 'no' if you do not want this."
+msgstr ""
+
 msgctxt "TC_CAT_DIAGNOSTICS"
 msgid "diagnostics"
 msgstr ""
@@ -2938,6 +3027,7 @@ msgctxt "TC_LABEL_OPT"
 msgid "option"
 msgstr ""
 
+#, c-format
 msgctxt "TC_MAIN_ERROR_LOAD_CONFIG"
 msgid "Loading config file \"%s\" failed, err = %d"
 msgstr ""
@@ -3149,6 +3239,7 @@ msgctxt "TC_STRING_CONF_NOTE"
 msgid "Values marked with an *asterisk are calculated internally by HTML Tidy"
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_OPT_NOT_DOCUMENTED"
 msgid "Warning: option `%s' is not documented."
 msgstr ""
@@ -3157,6 +3248,7 @@ msgctxt "TC_STRING_OUT_OF_MEMORY"
 msgid "Out of memory. Bailing out."
 msgstr ""
 
+#, c-format
 msgctxt "TC_STRING_FATAL_ERROR"
 msgid "Fatal error: impossible value for id='%d'."
 msgstr ""
@@ -3178,6 +3270,7 @@ msgid "A POSIX or Windows locale must be specified."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_LANG_NOT_FOUND"
 msgid "Tidy doesn't have language '%s,' will use '%s' instead."
 msgstr ""
@@ -3205,11 +3298,13 @@ msgid "HTML Tidy: unknown option."
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_A"
 msgid "HTML Tidy for %s version %s"
 msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_STRING_VERS_B"
 msgid "HTML Tidy version %s"
 msgstr ""
@@ -3218,6 +3313,7 @@ msgstr ""
 #. - %n represents the name of the executable from the file system, and is mostly like going to be "tidy".
 #. - %2 represents a version number, typically x.x.xx.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#, c-format
 msgctxt "TC_TXT_HELP_1"
 msgid ""
 "\n"
@@ -3230,6 +3326,7 @@ msgstr ""
 
 #. The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
 #. - %s represents the platform, for example, "Mac OS X" or "Windows".
+#, c-format
 msgctxt "TC_TXT_HELP_2A"
 msgid "Command Line Arguments for HTML Tidy for %s:"
 msgstr ""
@@ -3356,6 +3453,8 @@ msgstr ""
 
 #. This console output should be limited to 78 characters per line.
 #. - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+#. - The parameter %s is likely to be two to five characters, e.g., en or en_US.
+#, c-format
 msgctxt "TC_TXT_HELP_LANG_3"
 msgid ""
 "\n"
@@ -3363,6 +3462,8 @@ msgid ""
 "locale's language automatically. For example Unix-like systems use a \n"
 "$LANG and/or $LC_ALL environment variable. Consult your operating \n"
 "system documentation for more information. \n"
+"\n"
+"Tidy is currently using locale %s. \n"
 "\n"
 msgstr ""
 

--- a/src/language.c
+++ b/src/language.c
@@ -622,7 +622,7 @@ tmbstr tidyNormalizedLocaleName( ctmbstr locale )
     len = strlen( search );
     len = len <= 5 ? len : 5;
     
-    for ( i = 0; i < len; i++ )
+    for ( i = 0; i <= len; i++ )
     {
         if ( i == 2 )
         {

--- a/src/language_en.h
+++ b/src/language_en.h
@@ -2323,13 +2323,16 @@ static languageDefinition language_en = { whichPluralForm_en, {
         "\n"
     },
     {/* This console output should be limited to 78 characters per line.
-        - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
+        - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated.
+        - The parameter %s is likely to be two to five characters, e.g., en or en_US. */
       TC_TXT_HELP_LANG_3,           0,
         "\n"
         "If Tidy is able to determine your locale then Tidy will use the \n"
         "locale's language automatically. For example Unix-like systems use a \n"
         "$LANG and/or $LC_ALL environment variable. Consult your operating \n"
         "system documentation for more information. \n"
+        "\n"
+        "Tidy is currently using locale %s. \n"
         "\n"
     },
     

--- a/src/language_es.h
+++ b/src/language_es.h
@@ -124,6 +124,8 @@ static languageDefinition language_es = { whichPluralForm_es, {
         "$LANG y/o $LC_ALL. Consulte a su documentación del sistema para \n"
         "obtener más información.\n"
         "\n"
+        "Tidy está utilizando la configuración regional %s. \n"
+        "\n"
     },
 
     {/* This MUST be present and last. */

--- a/src/language_es.h
+++ b/src/language_es.h
@@ -28,7 +28,7 @@
  *
  * Orginating PO file metadata:
  *   PO_LAST_TRANSLATOR=jderry
- *   PO_REVISION_DATE=2016-02-17 20:04:18
+ *   PO_REVISION_DATE=2016-03-23 14:49:53
  */
 
 #ifdef _MSC_VER
@@ -65,23 +65,13 @@ static languageDefinition language_es = { whichPluralForm_es, {
     {/* Specify the ll or ll_cc language code here. */
       TIDY_LANGUAGE,          0, "es"
     },
-    {/* This console output should be limited to 78 characters per line. 
-      - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TEXT_GENERAL_INFO_PLEA, 0,        
+    { TEXT_GENERAL_INFO_PLEA, 0,        
         "\n"
         "¿Le gustaría ver Tidy en un español correcto? Por favor considere \n"
         "ayudarnos a localizar HTML Tidy. Para más detalles consulte \n"
         "https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md \n"
     },
-    {/* Important notes for translators:
-        - Use only <code></code>, <var></var>, <em></em>, <strong></strong>, and
-          <br/>.
-        - Entities, tags, attributes, etc., should be enclosed in <code></code>.
-        - Option values should be enclosed in <var></var>.
-        - It's very important that <br/> be self-closing!
-        - The strings "Tidy" and "HTML Tidy" are the program name and must not
-          be translated. */
-      TidyMakeClean,          0,        
+    { TidyMakeClean,          0,        
         "Esta opción especifica si Tidy debe realizar la limpieza de algún legado etiquetas de "
         "presentación (actualmente <code>&lt;i&gt;</code>, <code>&lt;b&gt;</code>, <code>&lt;center&gt;</"
         "code> cuando encerrados dentro de las etiquetas apropiadas en línea y <code>&lt;font&gt;</"
@@ -90,21 +80,10 @@ static languageDefinition language_es = { whichPluralForm_es, {
     },
 
 #if SUPPORT_ASIAN_ENCODINGS
-    {/* Important notes for translators:
-        - Use only <code></code>, <var></var>, <em></em>, <strong></strong>, and
-          <br/>.
-        - Entities, tags, attributes, etc., should be enclosed in <code></code>.
-        - Option values should be enclosed in <var></var>.
-        - It's very important that <br/> be self-closing!
-        - The strings "Tidy" and "HTML Tidy" are the program name and must not
-          be translated. */
-      TidyNCR,                0, "Esta opción especifica si Tidy debe permitir referencias de caracteres numéricos. "
-    },
+    { TidyNCR,                0, "Esta opción especifica si Tidy debe permitir referencias de caracteres numéricos. "   },
 #endif /* SUPPORT_ASIAN_ENCODINGS */
 
-    {/* This console output should be limited to 78 characters per line.
-        - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TC_TXT_HELP_LANG_1,     0,        
+    { TC_TXT_HELP_LANG_1,     0,        
         "\n"
         "La opción --language (o --lang) indica el lenguaje Tidy debe \n"
         "utilizar para comunicar su salida. Tenga en cuenta que esto no es \n"
@@ -124,10 +103,10 @@ static languageDefinition language_es = { whichPluralForm_es, {
         "La columna más a la derecha indica cómo Tidy comprenderá el \n"
         "legado nombre de Windows.\n"
         "\n"
+        "Tidy está utilizando la configuración regional %s. \n"
+        "\n"
     },
-    {/* This console output should be limited to 78 characters per line.
-        - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TC_TXT_HELP_LANG_2,     0,        
+    { TC_TXT_HELP_LANG_2,     0,        
         "\n"
         "Los siguientes idiomas están instalados actualmente en Tidy. Tenga \n"
         "en cuenta que no hay garantía de que están completos; sólo quiere decir \n"
@@ -137,9 +116,7 @@ static languageDefinition language_es = { whichPluralForm_es, {
         "necesario. ¡Favor de informar los desarrolladores de estes casos! \n"
         "\n"
     },
-    {/* This console output should be limited to 78 characters per line.
-        - The strings "Tidy" and "HTML Tidy" are the program name and must not be translated. */
-      TC_TXT_HELP_LANG_3,     0,        
+    { TC_TXT_HELP_LANG_3,     0,        
         "\n"
         "Si Tidy es capaz de determinar la configuración regional entonces \n"
         "Tidy utilizará el lenguaje de forma automática de la configuración \n"


### PR DESCRIPTION
This actually encompasses two other branches in addition to this one:
`localize_tuneup` to fix a couple of potool issues.
`locale_fix` which fixes the issue wherein a two-character language code wouldn't be set.
And this one, `lang_help_enhance` that adds the current locale to the --lang help output.
