### PR TITLE
Pair va_copy calls with va_end

### DIFF
--- a/src/message.c
+++ b/src/message.c
@@ -231,7 +231,7 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level, uint code,
     {
         va_list args_copy;
         va_copy(args_copy, args);
-        TY_(tmbvsnprintf)(messageBuf, sizeMessageBuf, msg, args);
+        TY_(tmbvsnprintf)(messageBuf, sizeMessageBuf, msg, args_copy);
         if ( doc->mssgFilt )
         {
             TidyDoc tdoc = tidyImplToDoc( doc );
@@ -245,6 +245,8 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level, uint code,
                consistent, we have to ensure that we only ever return the
                built-in English version of this string. */
             TidyDoc tdoc = tidyImplToDoc( doc );
+            va_end(args_copy);
+            va_copy(args_copy, args);
             go = go | doc->mssgFilt2( tdoc, level, line, col, tidyDefaultString(code), args_copy );
         }
         if ( doc->mssgFilt3 )
@@ -253,8 +255,11 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level, uint code,
                messages via their own means by providing a key string and
                the parameters to fill it. */
             TidyDoc tdoc = tidyImplToDoc( doc );
+            va_end(args_copy);
+            va_copy(args_copy, args);
             go = go | doc->mssgFilt3( tdoc, level, line, col, tidyErrorCodeAsString(code), args_copy );
         }
+        va_end(args_copy);
     }
 
     if ( go )


### PR DESCRIPTION
According to the C99 spec, each [`va_copy`](http://en.cppreference.com/w/c/variadic/va_copy) call should be matched by a [`va_end`](http://en.cppreference.com/w/c/variadic/va_end) call to ensure proper cleanup.  Furthermore, since message filters might iterate over the list of arguments, we should hand a new copy to each filter, for the unlikely event that some user installed more than one filter.