### PR TITLE
Make internal and external types equivalent

### DIFF
--- a/experimental/TidyNodeIter.c
+++ b/experimental/TidyNodeIter.c
@@ -3,7 +3,7 @@
 
 #include "TidyNodeIter.h"
 
-TidyNodeIter *newTidyNodeIter( Node *pStart )
+TidyNodeIter *newTidyNodeIter( TidyNode pStart )
 {
     TidyNodeIter *pThis = NULL;
     if (NULL != (pThis = MemAlloc( sizeof( TidyNodeIter ))))
@@ -14,7 +14,7 @@ TidyNodeIter *newTidyNodeIter( Node *pStart )
     return pThis;
 }
 
-Node *nextTidyNode( TidyNodeIter *pThis )
+TidyNode nextTidyNode( TidyNodeIter *pThis )
 {
     if (NULL == pThis->pCurrent)
     {
@@ -40,7 +40,7 @@ Node *nextTidyNode( TidyNodeIter *pThis )
     return pThis->pCurrent;
 }
 
-void setCurrentNode( TidyNodeIter *pThis, Node *newCurr )
+void setCurrentNode( TidyNodeIter *pThis, TidyNode newCurr )
 {
     if (NULL != newCurr)
         pThis->pCurrent = newCurr;

--- a/experimental/TidyNodeIter.h
+++ b/experimental/TidyNodeIter.h
@@ -8,7 +8,7 @@
 
   A traversal of the tree can be performed in a manner similar to the following:
 
-  Node *testNode;
+  TidyNode testNode;
   TidyNodeIter *iter = newTidyNodeIter( FindBody( tdoc ));
   for (testNode = nextTidyNode( &iter );
        NULL != testNode;
@@ -23,10 +23,10 @@
 
 typedef struct _TidyNodeIter
 {
-    Node *pTop, *pCurrent;
+    TidyNode pTop, *pCurrent;
 } TidyNodeIter;
 
-TidyNodeIter *newTidyNodeIter( Node *pStart );
+TidyNodeIter *newTidyNodeIter( TidyNode pStart );
 
 /* 
     nextTidyNode( TidyNodeIter *pIter )
@@ -36,10 +36,10 @@ TidyNodeIter *newTidyNodeIter( Node *pStart );
     and returns that value. When pTop == pCurrent, the function returns NULL
     to indicate that the entire tree has been visited.
 */
-Node *nextTidyNode( TidyNodeIter *pIter );
+TidyNode nextTidyNode( TidyNodeIter *pIter );
 
 /*
-    setCurrentNode( TidyNodeIter *pThis, Node *newCurr )
+    setCurrentNode( TidyNodeIter *pThis, TidyNode newCurr )
 
     Resets pCurrent to match the passed value; useful if you need to back up
     to an unaltered point in the tree, or to skip a section. The next call to 
@@ -48,4 +48,4 @@ Node *nextTidyNode( TidyNodeIter *pIter );
     Minimal error checking is performed; unexpected results _will_ occur if 
     newCurr is not a descendant node of pTop.
 */
-void setCurrentNode( TidyNodeIter *pThis, Node *newCurr );
+void setCurrentNode( TidyNodeIter *pThis, TidyNode newCurr );

--- a/include/tidy.h
+++ b/include/tidy.h
@@ -84,7 +84,8 @@ opaque_type( TidyDoc );
 /** @struct TidyOption
 **  Opaque option datatype
 */
-opaque_type( TidyOption );
+struct _tidy_option;
+typedef const struct _tidy_option * TidyOption;
 
 /** @struct TidyNode
 **  Opaque node datatype

--- a/include/tidyplatform.h
+++ b/include/tidyplatform.h
@@ -601,16 +601,13 @@ extern void* null;
 #endif
 
 /* Opaque data structure.
-*  Cast to implementation type struct within lib.
+*  The public header only declares these, but does not define them.
+*  The actual definition is restricted to the library code.
 *  This will reduce inter-dependencies/conflicts w/ application code.
 */
-#if 1
 #define opaque_type( typenam )\
-struct _##typenam { int _opaque; };\
-typedef struct _##typenam const * typenam
-#else
-#define opaque_type(typenam) typedef const void* typenam
-#endif
+struct _##typenam;\
+typedef struct _##typenam * typenam
 
 /* Opaque data structure used to pass back
 ** and forth to keep current position in a

--- a/src/access.h
+++ b/src/access.h
@@ -89,7 +89,7 @@ struct _TidyAccessImpl
     Bool HasMap;
 
     /* For tracking nodes that are deleted from the original parse tree - TRT */
-    /* Node *access_tree; */
+    /* TidyNode access_tree; */
 
     Bool HasTH;
     Bool HasValidFor;
@@ -263,8 +263,8 @@ typedef enum
 } accessErrorCodes;
 
 
-void TY_(AccessibilityHelloMessage)( TidyDocImpl* doc );
-void TY_(DisplayHTMLTableAlgorithm)( TidyDocImpl* doc );
+void TY_(AccessibilityHelloMessage)( TidyDoc doc );
+void TY_(DisplayHTMLTableAlgorithm)( TidyDoc doc );
 
 /************************************************************
 * AccessibilityChecks
@@ -274,7 +274,7 @@ void TY_(DisplayHTMLTableAlgorithm)( TidyDocImpl* doc );
 * after the tree structure has been formed.
 ************************************************************/
 
-void TY_(AccessibilityChecks)( TidyDocImpl* doc );
+void TY_(AccessibilityChecks)( TidyDoc doc );
 
 
 #endif /* SUPPORT_ACCESSIBILITY_CHECKS */

--- a/src/attrask.c
+++ b/src/attrask.c
@@ -11,187 +11,187 @@
 
 Bool TIDY_CALL tidyAttrIsHREF( TidyAttr tattr )
 {
-    return attrIsHREF( tidyAttrToImpl(tattr) );
+    return attrIsHREF( tattr );
 }
 Bool TIDY_CALL tidyAttrIsSRC( TidyAttr tattr )
 {
-    return attrIsSRC( tidyAttrToImpl(tattr) );
+    return attrIsSRC( tattr );
 }
 Bool TIDY_CALL tidyAttrIsID( TidyAttr tattr )
 {
-    return attrIsID( tidyAttrToImpl(tattr) );
+    return attrIsID( tattr );
 }
 Bool TIDY_CALL tidyAttrIsNAME( TidyAttr tattr )
 {
-    return attrIsNAME( tidyAttrToImpl(tattr) );
+    return attrIsNAME( tattr );
 }
 Bool TIDY_CALL tidyAttrIsSUMMARY( TidyAttr tattr )
 {
-    return attrIsSUMMARY( tidyAttrToImpl(tattr) );
+    return attrIsSUMMARY( tattr );
 }
 Bool TIDY_CALL tidyAttrIsALT( TidyAttr tattr )
 {
-    return attrIsALT( tidyAttrToImpl(tattr) );
+    return attrIsALT( tattr );
 }
 Bool TIDY_CALL tidyAttrIsLONGDESC( TidyAttr tattr )
 {
-    return attrIsLONGDESC( tidyAttrToImpl(tattr) );
+    return attrIsLONGDESC( tattr );
 }
 Bool TIDY_CALL tidyAttrIsUSEMAP( TidyAttr tattr )
 {
-    return attrIsUSEMAP( tidyAttrToImpl(tattr) );
+    return attrIsUSEMAP( tattr );
 }
 Bool TIDY_CALL tidyAttrIsISMAP( TidyAttr tattr )
 {
-    return attrIsISMAP( tidyAttrToImpl(tattr) );
+    return attrIsISMAP( tattr );
 }
 Bool TIDY_CALL tidyAttrIsLANGUAGE( TidyAttr tattr )
 {
-    return attrIsLANGUAGE( tidyAttrToImpl(tattr) );
+    return attrIsLANGUAGE( tattr );
 }
 Bool TIDY_CALL tidyAttrIsTYPE( TidyAttr tattr )
 {
-    return attrIsTYPE( tidyAttrToImpl(tattr) );
+    return attrIsTYPE( tattr );
 }
 Bool TIDY_CALL tidyAttrIsVALUE( TidyAttr tattr )
 {
-    return attrIsVALUE( tidyAttrToImpl(tattr) );
+    return attrIsVALUE( tattr );
 }
 Bool TIDY_CALL tidyAttrIsCONTENT( TidyAttr tattr )
 {
-    return attrIsCONTENT( tidyAttrToImpl(tattr) );
+    return attrIsCONTENT( tattr );
 }
 Bool TIDY_CALL tidyAttrIsTITLE( TidyAttr tattr )
 {
-    return attrIsTITLE( tidyAttrToImpl(tattr) );
+    return attrIsTITLE( tattr );
 }
 Bool TIDY_CALL tidyAttrIsXMLNS( TidyAttr tattr )
 {
-    return attrIsXMLNS( tidyAttrToImpl(tattr) );
+    return attrIsXMLNS( tattr );
 }
 Bool TIDY_CALL tidyAttrIsDATAFLD( TidyAttr tattr )
 {
-    return attrIsDATAFLD( tidyAttrToImpl(tattr) );
+    return attrIsDATAFLD( tattr );
 }
 Bool TIDY_CALL tidyAttrIsWIDTH( TidyAttr tattr )
 {
-    return attrIsWIDTH( tidyAttrToImpl(tattr) );
+    return attrIsWIDTH( tattr );
 }
 Bool TIDY_CALL tidyAttrIsHEIGHT( TidyAttr tattr )
 {
-    return attrIsHEIGHT( tidyAttrToImpl(tattr) );
+    return attrIsHEIGHT( tattr );
 }
 Bool TIDY_CALL tidyAttrIsFOR( TidyAttr tattr )
 {
-    return attrIsFOR( tidyAttrToImpl(tattr) );
+    return attrIsFOR( tattr );
 }
 Bool TIDY_CALL tidyAttrIsSELECTED( TidyAttr tattr )
 {
-    return attrIsSELECTED( tidyAttrToImpl(tattr) );
+    return attrIsSELECTED( tattr );
 }
 Bool TIDY_CALL tidyAttrIsCHECKED( TidyAttr tattr )
 {
-    return attrIsCHECKED( tidyAttrToImpl(tattr) );
+    return attrIsCHECKED( tattr );
 }
 Bool TIDY_CALL tidyAttrIsLANG( TidyAttr tattr )
 {
-    return attrIsLANG( tidyAttrToImpl(tattr) );
+    return attrIsLANG( tattr );
 }
 Bool TIDY_CALL tidyAttrIsTARGET( TidyAttr tattr )
 {
-    return attrIsTARGET( tidyAttrToImpl(tattr) );
+    return attrIsTARGET( tattr );
 }
 Bool TIDY_CALL tidyAttrIsHTTP_EQUIV( TidyAttr tattr )
 {
-    return attrIsHTTP_EQUIV( tidyAttrToImpl(tattr) );
+    return attrIsHTTP_EQUIV( tattr );
 }
 Bool TIDY_CALL tidyAttrIsREL( TidyAttr tattr )
 {
-    return attrIsREL( tidyAttrToImpl(tattr) );
+    return attrIsREL( tattr );
 }
 Bool TIDY_CALL tidyAttrIsEvent( TidyAttr tattr )
 {
-    return TY_(attrIsEvent)( tidyAttrToImpl(tattr) );
+    return TY_(attrIsEvent)( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnMOUSEMOVE( TidyAttr tattr )
 {
-    return attrIsOnMOUSEMOVE( tidyAttrToImpl(tattr) );
+    return attrIsOnMOUSEMOVE( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnMOUSEDOWN( TidyAttr tattr )
 {
-    return attrIsOnMOUSEDOWN( tidyAttrToImpl(tattr) );
+    return attrIsOnMOUSEDOWN( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnMOUSEUP( TidyAttr tattr )
 {
-    return attrIsOnMOUSEUP( tidyAttrToImpl(tattr) );
+    return attrIsOnMOUSEUP( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnCLICK( TidyAttr tattr )
 {
-    return attrIsOnCLICK( tidyAttrToImpl(tattr) );
+    return attrIsOnCLICK( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnMOUSEOVER( TidyAttr tattr )
 {
-    return attrIsOnMOUSEOVER( tidyAttrToImpl(tattr) );
+    return attrIsOnMOUSEOVER( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnMOUSEOUT( TidyAttr tattr )
 {
-    return attrIsOnMOUSEOUT( tidyAttrToImpl(tattr) );
+    return attrIsOnMOUSEOUT( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnKEYDOWN( TidyAttr tattr )
 {
-    return attrIsOnKEYDOWN( tidyAttrToImpl(tattr) );
+    return attrIsOnKEYDOWN( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnKEYUP( TidyAttr tattr )
 {
-    return attrIsOnKEYUP( tidyAttrToImpl(tattr) );
+    return attrIsOnKEYUP( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnKEYPRESS( TidyAttr tattr )
 {
-    return attrIsOnKEYPRESS( tidyAttrToImpl(tattr) );
+    return attrIsOnKEYPRESS( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnFOCUS( TidyAttr tattr )
 {
-    return attrIsOnFOCUS( tidyAttrToImpl(tattr) );
+    return attrIsOnFOCUS( tattr );
 }
 Bool TIDY_CALL tidyAttrIsOnBLUR( TidyAttr tattr )
 {
-    return attrIsOnBLUR( tidyAttrToImpl(tattr) );
+    return attrIsOnBLUR( tattr );
 }
 Bool TIDY_CALL tidyAttrIsBGCOLOR( TidyAttr tattr )
 {
-    return attrIsBGCOLOR( tidyAttrToImpl(tattr) );
+    return attrIsBGCOLOR( tattr );
 }
 Bool TIDY_CALL tidyAttrIsLINK( TidyAttr tattr )
 {
-    return attrIsLINK( tidyAttrToImpl(tattr) );
+    return attrIsLINK( tattr );
 }
 Bool TIDY_CALL tidyAttrIsALINK( TidyAttr tattr )
 {
-    return attrIsALINK( tidyAttrToImpl(tattr) );
+    return attrIsALINK( tattr );
 }
 Bool TIDY_CALL tidyAttrIsVLINK( TidyAttr tattr )
 {
-    return attrIsVLINK( tidyAttrToImpl(tattr) );
+    return attrIsVLINK( tattr );
 }
 Bool TIDY_CALL tidyAttrIsTEXT( TidyAttr tattr )
 {
-    return attrIsTEXT( tidyAttrToImpl(tattr) );
+    return attrIsTEXT( tattr );
 }
 Bool TIDY_CALL tidyAttrIsSTYLE( TidyAttr tattr )
 {
-    return attrIsSTYLE( tidyAttrToImpl(tattr) );
+    return attrIsSTYLE( tattr );
 }
 Bool TIDY_CALL tidyAttrIsABBR( TidyAttr tattr )
 {
-    return attrIsABBR( tidyAttrToImpl(tattr) );
+    return attrIsABBR( tattr );
 }
 Bool TIDY_CALL tidyAttrIsCOLSPAN( TidyAttr tattr )
 {
-    return attrIsCOLSPAN( tidyAttrToImpl(tattr) );
+    return attrIsCOLSPAN( tattr );
 }
 Bool TIDY_CALL tidyAttrIsROWSPAN( TidyAttr tattr )
 {
-    return attrIsROWSPAN( tidyAttrToImpl(tattr) );
+    return attrIsROWSPAN( tattr );
 }
 
 /*

--- a/src/attrget.c
+++ b/src/attrget.c
@@ -12,190 +12,189 @@
 
 TidyAttr TIDY_CALL tidyAttrGetById( TidyNode tnod, TidyAttrId attId )
 {
-    TidyNode nimp = tidyNodeToImpl(tnod);
-    return tidyImplToAttr( TY_(AttrGetById)( nimp, attId ) );
+    return TY_(AttrGetById)( tnod, attId );
 }
 TidyAttr TIDY_CALL tidyAttrGetHREF( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetHREF( tidyNodeToImpl(tnod) ) );
+    return attrGetHREF( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetSRC( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetSRC( tidyNodeToImpl(tnod) ) );
+    return attrGetSRC( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetID( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetID( tidyNodeToImpl(tnod) ) );
+    return attrGetID( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetNAME( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetNAME( tidyNodeToImpl(tnod) ) );
+    return attrGetNAME( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetSUMMARY( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetSUMMARY( tidyNodeToImpl(tnod) ) );
+    return attrGetSUMMARY( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetALT( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetALT( tidyNodeToImpl(tnod) ) );
+    return attrGetALT( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetLONGDESC( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetLONGDESC( tidyNodeToImpl(tnod) ) );
+    return attrGetLONGDESC( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetUSEMAP( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetUSEMAP( tidyNodeToImpl(tnod) ) );
+    return attrGetUSEMAP( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetISMAP( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetISMAP( tidyNodeToImpl(tnod) ) );
+    return attrGetISMAP( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetLANGUAGE( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetLANGUAGE( tidyNodeToImpl(tnod) ) );
+    return attrGetLANGUAGE( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetTYPE( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetTYPE( tidyNodeToImpl(tnod) ) );
+    return attrGetTYPE( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetVALUE( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetVALUE( tidyNodeToImpl(tnod) ) );
+    return attrGetVALUE( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetCONTENT( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetCONTENT( tidyNodeToImpl(tnod) ) );
+    return attrGetCONTENT( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetTITLE( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetTITLE( tidyNodeToImpl(tnod) ) );
+    return attrGetTITLE( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetXMLNS( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetXMLNS( tidyNodeToImpl(tnod) ) );
+    return attrGetXMLNS( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetDATAFLD( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetDATAFLD( tidyNodeToImpl(tnod) ) );
+    return attrGetDATAFLD( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetWIDTH( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetWIDTH( tidyNodeToImpl(tnod) ) );
+    return attrGetWIDTH( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetHEIGHT( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetHEIGHT( tidyNodeToImpl(tnod) ) );
+    return attrGetHEIGHT( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetFOR( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetFOR( tidyNodeToImpl(tnod) ) );
+    return attrGetFOR( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetSELECTED( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetSELECTED( tidyNodeToImpl(tnod) ) );
+    return attrGetSELECTED( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetCHECKED( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetCHECKED( tidyNodeToImpl(tnod) ) );
+    return attrGetCHECKED( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetLANG( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetLANG( tidyNodeToImpl(tnod) ) );
+    return attrGetLANG( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetTARGET( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetTARGET( tidyNodeToImpl(tnod) ) );
+    return attrGetTARGET( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetHTTP_EQUIV( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetHTTP_EQUIV( tidyNodeToImpl(tnod) ) );
+    return attrGetHTTP_EQUIV( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetREL( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetREL( tidyNodeToImpl(tnod) ) );
+    return attrGetREL( tnod );
 }
 
 TidyAttr TIDY_CALL tidyAttrGetOnMOUSEMOVE( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnMOUSEMOVE( tidyNodeToImpl(tnod) ) );
+    return attrGetOnMOUSEMOVE( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnMOUSEDOWN( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnMOUSEDOWN( tidyNodeToImpl(tnod) ) );
+    return attrGetOnMOUSEDOWN( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnMOUSEUP( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnMOUSEUP( tidyNodeToImpl(tnod) ) );
+    return attrGetOnMOUSEUP( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnCLICK( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnCLICK( tidyNodeToImpl(tnod) ) );
+    return attrGetOnCLICK( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnMOUSEOVER( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnMOUSEOVER( tidyNodeToImpl(tnod) ) );
+    return attrGetOnMOUSEOVER( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnMOUSEOUT( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnMOUSEOUT( tidyNodeToImpl(tnod) ) );
+    return attrGetOnMOUSEOUT( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnKEYDOWN( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnKEYDOWN( tidyNodeToImpl(tnod) ) );
+    return attrGetOnKEYDOWN( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnKEYUP( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnKEYUP( tidyNodeToImpl(tnod) ) );
+    return attrGetOnKEYUP( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnKEYPRESS( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnKEYPRESS( tidyNodeToImpl(tnod) ) );
+    return attrGetOnKEYPRESS( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnFOCUS( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnFOCUS( tidyNodeToImpl(tnod) ) );
+    return attrGetOnFOCUS( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetOnBLUR( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetOnBLUR( tidyNodeToImpl(tnod) ) );
+    return attrGetOnBLUR( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetBGCOLOR( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetBGCOLOR( tidyNodeToImpl(tnod) ) );
+    return attrGetBGCOLOR( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetLINK( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetLINK( tidyNodeToImpl(tnod) ) );
+    return attrGetLINK( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetALINK( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetALINK( tidyNodeToImpl(tnod) ) );
+    return attrGetALINK( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetVLINK( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetVLINK( tidyNodeToImpl(tnod) ) );
+    return attrGetVLINK( tnod );
 }
 
 TidyAttr TIDY_CALL tidyAttrGetTEXT( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetTEXT( tidyNodeToImpl(tnod) ) );
+    return attrGetTEXT( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetSTYLE( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetSTYLE( tidyNodeToImpl(tnod) ) );
+    return attrGetSTYLE( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetABBR( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetABBR( tidyNodeToImpl(tnod) ) );
+    return attrGetABBR( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetCOLSPAN( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetCOLSPAN( tidyNodeToImpl(tnod) ) );
+    return attrGetCOLSPAN( tnod );
 }
 TidyAttr TIDY_CALL tidyAttrGetROWSPAN( TidyNode tnod )
 {
-    return tidyImplToAttr( attrGetROWSPAN( tidyNodeToImpl(tnod) ) );
+    return attrGetROWSPAN( tnod );
 }
 
 /*

--- a/src/attrget.c
+++ b/src/attrget.c
@@ -12,7 +12,7 @@
 
 TidyAttr TIDY_CALL tidyAttrGetById( TidyNode tnod, TidyAttrId attId )
 {
-    Node* nimp = tidyNodeToImpl(tnod);
+    TidyNode nimp = tidyNodeToImpl(tnod);
     return tidyImplToAttr( TY_(AttrGetById)( nimp, attId ) );
 }
 TidyAttr TIDY_CALL tidyAttrGetHREF( TidyNode tnod )

--- a/src/attrs.h
+++ b/src/attrs.h
@@ -11,7 +11,7 @@
 #include "forward.h"
 
 /* declaration for methods that check attribute values */
-typedef void (AttrCheck)(TidyDocImpl* doc, Node *node, AttVal *attval);
+typedef void (AttrCheck)(TidyDoc doc, TidyNode node, TidyAttr attval);
 
 struct _Attribute
 {
@@ -30,7 +30,7 @@ struct _Attribute
 struct _Anchor
 {
     struct _Anchor *next;
-    Node *node;
+    TidyNode node;
     char *name;
 };
 
@@ -80,27 +80,27 @@ typedef struct _TidyAttribImpl TidyAttribImpl;
 AttrCheck TY_(CheckUrl);
 
 /* public method for finding attribute definition by name */
-const Attribute* TY_(CheckAttribute)( TidyDocImpl* doc, Node *node, AttVal *attval );
+const Attribute* TY_(CheckAttribute)( TidyDoc doc, TidyNode node, TidyAttr attval );
 
-const Attribute* TY_(FindAttribute)( TidyDocImpl* doc, AttVal *attval );
+const Attribute* TY_(FindAttribute)( TidyDoc doc, TidyAttr attval );
 
-AttVal* TY_(GetAttrByName)( Node *node, ctmbstr name );
+TidyAttr TY_(GetAttrByName)( TidyNode node, ctmbstr name );
 
-void TY_(DropAttrByName)( TidyDocImpl* doc, Node *node, ctmbstr name );
+void TY_(DropAttrByName)( TidyDoc doc, TidyNode node, ctmbstr name );
 
-AttVal* TY_(AddAttribute)( TidyDocImpl* doc,
-                           Node *node, ctmbstr name, ctmbstr value );
+TidyAttr TY_(AddAttribute)( TidyDoc doc,
+                           TidyNode node, ctmbstr name, ctmbstr value );
 
-AttVal* TY_(RepairAttrValue)(TidyDocImpl* doc, Node* node, ctmbstr name, ctmbstr value);
+TidyAttr TY_(RepairAttrValue)(TidyDoc doc, TidyNode node, ctmbstr name, ctmbstr value);
 
-Bool TY_(IsUrl)( TidyDocImpl* doc, ctmbstr attrname );
+Bool TY_(IsUrl)( TidyDoc doc, ctmbstr attrname );
 
-/* Bool IsBool( TidyDocImpl* doc, ctmbstr attrname ); */
+/* Bool IsBool( TidyDoc doc, ctmbstr attrname ); */
 
-Bool TY_(IsScript)( TidyDocImpl* doc, ctmbstr attrname );
+Bool TY_(IsScript)( TidyDoc doc, ctmbstr attrname );
 
 /* may id or name serve as anchor? */
-Bool TY_(IsAnchorElement)( TidyDocImpl* doc, Node* node );
+Bool TY_(IsAnchorElement)( TidyDoc doc, TidyNode node );
 
 /*
   In CSS1, selectors can contain only the characters A-Z, 0-9, and
@@ -122,33 +122,33 @@ Bool TY_(IsValidHTMLID)(ctmbstr id);
 Bool TY_(IsValidXMLID)(ctmbstr id);
 
 /* removes anchor for specific node */
-void TY_(RemoveAnchorByNode)( TidyDocImpl* doc, ctmbstr name, Node *node );
+void TY_(RemoveAnchorByNode)( TidyDoc doc, ctmbstr name, TidyNode node );
 
 /* free all anchors */
-void TY_(FreeAnchors)( TidyDocImpl* doc );
+void TY_(FreeAnchors)( TidyDoc doc );
 
 
 /* public methods for inititializing/freeing attribute dictionary */
-void TY_(InitAttrs)( TidyDocImpl* doc );
-void TY_(FreeAttrTable)( TidyDocImpl* doc );
+void TY_(InitAttrs)( TidyDoc doc );
+void TY_(FreeAttrTable)( TidyDoc doc );
 
-void TY_(AppendToClassAttr)( TidyDocImpl* doc, AttVal *classattr, ctmbstr classname );
+void TY_(AppendToClassAttr)( TidyDoc doc, TidyAttr classattr, ctmbstr classname );
 /*
  the same attribute name can't be used
  more than once in each element
 */
-void TY_(RepairDuplicateAttributes)( TidyDocImpl* doc, Node* node, Bool isXml );
-void TY_(SortAttributes)(Node* node, TidyAttrSortStrategy strat);
+void TY_(RepairDuplicateAttributes)( TidyDoc doc, TidyNode node, Bool isXml );
+void TY_(SortAttributes)(TidyNode node, TidyAttrSortStrategy strat);
 
-Bool TY_(IsBoolAttribute)( AttVal* attval );
-Bool TY_(attrIsEvent)( AttVal* attval );
+Bool TY_(IsBoolAttribute)( TidyAttr attval );
+Bool TY_(attrIsEvent)( TidyAttr attval );
 
-AttVal* TY_(AttrGetById)( Node* node, TidyAttrId id );
+TidyAttr TY_(AttrGetById)( TidyNode node, TidyAttrId id );
 
-uint TY_(NodeAttributeVersions)( Node* node, TidyAttrId id );
+uint TY_(NodeAttributeVersions)( TidyNode node, TidyAttrId id );
 
-Bool TY_(AttributeIsProprietary)(Node* node, AttVal* attval);
-Bool TY_(AttributeIsMismatched)(Node* node, AttVal* attval, TidyDocImpl* doc);
+Bool TY_(AttributeIsProprietary)(TidyNode node, TidyAttr attval);
+Bool TY_(AttributeIsMismatched)(TidyNode node, TidyAttr attval, TidyDoc doc);
 
 
 /* 0 == TidyAttr_UNKNOWN  */

--- a/src/clean.h
+++ b/src/clean.h
@@ -8,22 +8,22 @@
 
 */
 
-void TY_(FixNodeLinks)(Node *node);
+void TY_(FixNodeLinks)(TidyNode node);
 
-void TY_(FreeStyles)( TidyDocImpl* doc );
+void TY_(FreeStyles)( TidyDoc doc );
 
 /* Add class="foo" to node
 */
-void TY_(AddStyleAsClass)( TidyDocImpl* doc, Node *node, ctmbstr stylevalue );
-void TY_(AddStyleProperty)(TidyDocImpl* doc, Node *node, ctmbstr property );
+void TY_(AddStyleAsClass)( TidyDoc doc, TidyNode node, ctmbstr stylevalue );
+void TY_(AddStyleProperty)(TidyDoc doc, TidyNode node, ctmbstr property );
 
-void TY_(CleanDocument)( TidyDocImpl* doc );
+void TY_(CleanDocument)( TidyDoc doc );
 
 /* simplifies <b><b> ... </b> ...</b> etc. */
-void TY_(NestedEmphasis)( TidyDocImpl* doc, Node* node );
+void TY_(NestedEmphasis)( TidyDoc doc, TidyNode node );
 
 /* replace i by em and b by strong */
-void TY_(EmFromI)( TidyDocImpl* doc, Node* node );
+void TY_(EmFromI)( TidyDoc doc, TidyNode node );
 
 /*
  Some people use dir or ul without an li
@@ -32,17 +32,17 @@ void TY_(EmFromI)( TidyDocImpl* doc, Node* node );
  li. This is recursively replaced by an
  implicit blockquote.
 */
-void TY_(List2BQ)( TidyDocImpl* doc, Node* node );
+void TY_(List2BQ)( TidyDoc doc, TidyNode node );
 
 /*
  Replace implicit blockquote by div with an indent
  taking care to reduce nested blockquotes to a single
  div with the indent set to match the nesting depth
 */
-void TY_(BQ2Div)( TidyDocImpl* doc, Node* node );
+void TY_(BQ2Div)( TidyDoc doc, TidyNode node );
 
 
-void TY_(DropSections)( TidyDocImpl* doc, Node* node );
+void TY_(DropSections)( TidyDoc doc, TidyNode node );
 
 
 /*
@@ -52,31 +52,31 @@ void TY_(DropSections)( TidyDocImpl* doc, Node* node );
  declare them as new tags, such as o:p which needs to be declared
  as inline.
 */
-void TY_(CleanWord2000)( TidyDocImpl* doc, Node *node);
+void TY_(CleanWord2000)( TidyDoc doc, TidyNode node);
 
-Bool TY_(IsWord2000)( TidyDocImpl* doc );
+Bool TY_(IsWord2000)( TidyDoc doc );
 
 /* where appropriate move object elements from head to body */
-void TY_(BumpObject)( TidyDocImpl* doc, Node *html );
+void TY_(BumpObject)( TidyDoc doc, TidyNode html );
 
 /* This is disabled due to http://tidy.sf.net/bug/681116 */
 #if 0
-void TY_(FixBrakes)( TidyDocImpl* pDoc, Node *pParent );
+void TY_(FixBrakes)( TidyDoc pDoc, TidyNode pParent );
 #endif
 
-void TY_(VerifyHTTPEquiv)( TidyDocImpl* pDoc, Node *pParent );
+void TY_(VerifyHTTPEquiv)( TidyDoc pDoc, TidyNode pParent );
 
-void TY_(DropComments)(TidyDocImpl* doc, Node* node);
-void TY_(DropFontElements)(TidyDocImpl* doc, Node* node, Node **pnode);
-void TY_(WbrToSpace)(TidyDocImpl* doc, Node* node);
-void TY_(DowngradeTypography)(TidyDocImpl* doc, Node* node);
-void TY_(ReplacePreformattedSpaces)(TidyDocImpl* doc, Node* node);
-void TY_(NormalizeSpaces)(Lexer *lexer, Node *node);
-void TY_(ConvertCDATANodes)(TidyDocImpl* doc, Node* node);
+void TY_(DropComments)(TidyDoc doc, TidyNode node);
+void TY_(DropFontElements)(TidyDoc doc, TidyNode node, TidyNode *pnode);
+void TY_(WbrToSpace)(TidyDoc doc, TidyNode node);
+void TY_(DowngradeTypography)(TidyDoc doc, TidyNode node);
+void TY_(ReplacePreformattedSpaces)(TidyDoc doc, TidyNode node);
+void TY_(NormalizeSpaces)(Lexer *lexer, TidyNode node);
+void TY_(ConvertCDATANodes)(TidyDoc doc, TidyNode node);
 
-void TY_(FixAnchors)(TidyDocImpl* doc, Node *node, Bool wantName, Bool wantId);
-void TY_(FixXhtmlNamespace)(TidyDocImpl* doc, Bool wantXmlns);
-void TY_(FixLanguageInformation)(TidyDocImpl* doc, Node* node, Bool wantXmlLang, Bool wantLang);
+void TY_(FixAnchors)(TidyDoc doc, TidyNode node, Bool wantName, Bool wantId);
+void TY_(FixXhtmlNamespace)(TidyDoc doc, Bool wantXmlns);
+void TY_(FixLanguageInformation)(TidyDoc doc, TidyNode node, Bool wantXmlLang, Bool wantLang);
 
 
 #endif /* __CLEAN_H__ */

--- a/src/config.c
+++ b/src/config.c
@@ -762,9 +762,8 @@ static ctmbstr ExpandTilde( TidyDoc doc, ctmbstr filename )
     return (ctmbstr) filename;
 }
 
-Bool TIDY_CALL tidyFileExists( TidyDoc tdoc, ctmbstr filename )
+Bool TIDY_CALL tidyFileExists( TidyDoc doc, ctmbstr filename )
 {
-  TidyDoc doc = tidyDocToImpl( tdoc );
   ctmbstr fname = (tmbstr) ExpandTilde( doc, filename );
 #ifndef NO_ACCESS_SUPPORT
   Bool exists = ( access(fname, 0) == 0 );

--- a/src/config.c
+++ b/src/config.c
@@ -43,13 +43,13 @@
 #include "win32tc.h"
 #endif
 
-void TY_(InitConfig)( TidyDocImpl* doc )
+void TY_(InitConfig)( TidyDoc doc )
 {
     TidyClearMemory( &doc->config, sizeof(TidyConfigImpl) );
     TY_(ResetConfigToDefault)( doc );
 }
 
-void TY_(FreeConfig)( TidyDocImpl* doc )
+void TY_(FreeConfig)( TidyDoc doc )
 {
     TY_(ResetConfigToDefault)( doc );
     TY_(TakeConfigSnapshot)( doc );
@@ -165,7 +165,7 @@ static const ctmbstr sorterPicks[] =
 #define ParseAcc NULL 
 #endif
 
-static void AdjustConfig( TidyDocImpl* doc );
+static void AdjustConfig( TidyDoc doc );
 
 /* parser for integer values */
 static ParseProperty ParseInt;
@@ -212,7 +212,7 @@ static ParseProperty ParseRepeatAttr;
 \*/
 static ParseProperty ParseTabs;
 
-static const TidyOptionImpl option_defs[] =
+static const struct _tidy_option option_defs[] =
 {
   { TidyUnknownOption,           MS, "unknown!",                    IN, 0,               NULL,              NULL            },
   { TidyIndentSpaces,            PP, "indent-spaces",               IN, 2,               ParseInt,          NULL            },
@@ -331,9 +331,9 @@ static const TidyOptionImpl option_defs[] =
 ** thus, it is cheaper to do a few scans than set
 ** up every option in a hash table.
 */
-const TidyOptionImpl* TY_(lookupOption)( ctmbstr s )
+TidyOption TY_(lookupOption)( ctmbstr s )
 {
-    const TidyOptionImpl* np = option_defs;
+    TidyOption np = option_defs;
     for ( /**/; np < option_defs + N_TIDY_OPTIONS; ++np )
     {
         if ( TY_(tmbstrcasecmp)(s, np->name) == 0 )
@@ -342,7 +342,7 @@ const TidyOptionImpl* TY_(lookupOption)( ctmbstr s )
     return NULL;
 }
 
-const TidyOptionImpl* TY_(getOption)( TidyOptionId optId )
+TidyOption TY_(getOption)( TidyOptionId optId )
 {
   if ( optId < N_TIDY_OPTIONS )
       return option_defs + optId;
@@ -350,13 +350,13 @@ const TidyOptionImpl* TY_(getOption)( TidyOptionId optId )
 }
 
 
-static void FreeOptionValue( TidyDocImpl* doc, const TidyOptionImpl* option, TidyOptionValue* value )
+static void FreeOptionValue( TidyDoc doc, TidyOption option, TidyOptionValue* value )
 {
     if ( option->type == TidyString && value->p && value->p != option->pdflt )
         TidyDocFree( doc, value->p );
 }
 
-static void CopyOptionValue( TidyDocImpl* doc, const TidyOptionImpl* option,
+static void CopyOptionValue( TidyDoc doc, TidyOption option,
                              TidyOptionValue* oldval, const TidyOptionValue* newval )
 {
     assert( oldval != NULL );
@@ -374,9 +374,9 @@ static void CopyOptionValue( TidyDocImpl* doc, const TidyOptionImpl* option,
 }
 
 
-static Bool SetOptionValue( TidyDocImpl* doc, TidyOptionId optId, ctmbstr val )
+static Bool SetOptionValue( TidyDoc doc, TidyOptionId optId, ctmbstr val )
 {
-   const TidyOptionImpl* option = &option_defs[ optId ];
+   TidyOption option = &option_defs[ optId ];
    Bool status = ( optId < N_TIDY_OPTIONS );
    if ( status )
    {
@@ -390,7 +390,7 @@ static Bool SetOptionValue( TidyDocImpl* doc, TidyOptionId optId, ctmbstr val )
    return status;
 }
 
-Bool TY_(SetOptionInt)( TidyDocImpl* doc, TidyOptionId optId, ulong val )
+Bool TY_(SetOptionInt)( TidyDoc doc, TidyOptionId optId, ulong val )
 {
    Bool status = ( optId < N_TIDY_OPTIONS );
    if ( status )
@@ -401,7 +401,7 @@ Bool TY_(SetOptionInt)( TidyDocImpl* doc, TidyOptionId optId, ulong val )
    return status;
 }
 
-Bool TY_(SetOptionBool)( TidyDocImpl* doc, TidyOptionId optId, Bool val )
+Bool TY_(SetOptionBool)( TidyDoc doc, TidyOptionId optId, Bool val )
 {
    Bool status = ( optId < N_TIDY_OPTIONS );
    if ( status )
@@ -412,7 +412,7 @@ Bool TY_(SetOptionBool)( TidyDocImpl* doc, TidyOptionId optId, Bool val )
    return status;
 }
 
-static void GetOptionDefault( const TidyOptionImpl* option,
+static void GetOptionDefault( TidyOption option,
                               TidyOptionValue* dflt )
 {
     if ( option->type == TidyString )
@@ -421,7 +421,7 @@ static void GetOptionDefault( const TidyOptionImpl* option,
         dflt->v = option->dflt;
 }
 
-static Bool OptionValueEqDefault( const TidyOptionImpl* option,
+static Bool OptionValueEqDefault( TidyOption option,
                                   const TidyOptionValue* val )
 {
     return ( option->type == TidyString ) ?
@@ -429,13 +429,13 @@ static Bool OptionValueEqDefault( const TidyOptionImpl* option,
         val->v == option->dflt;
 }
 
-Bool TY_(ResetOptionToDefault)( TidyDocImpl* doc, TidyOptionId optId )
+Bool TY_(ResetOptionToDefault)( TidyDoc doc, TidyOptionId optId )
 {
     Bool status = ( optId > 0 && optId < N_TIDY_OPTIONS );
     if ( status )
     {
         TidyOptionValue dflt;
-        const TidyOptionImpl* option = option_defs + optId;
+        TidyOption option = option_defs + optId;
         TidyOptionValue* value = &doc->config.value[ optId ];
         assert( optId == option->id );
         GetOptionDefault( option, &dflt );
@@ -444,7 +444,7 @@ Bool TY_(ResetOptionToDefault)( TidyDocImpl* doc, TidyOptionId optId )
     return status;
 }
 
-static void ReparseTagType( TidyDocImpl* doc, TidyOptionId optId )
+static void ReparseTagType( TidyDoc doc, TidyOptionId optId )
 {
     ctmbstr tagdecl = cfgStr( doc, optId );
     tmbstr dupdecl = TY_(tmbstrdup)( doc->allocator, tagdecl );
@@ -452,7 +452,7 @@ static void ReparseTagType( TidyDocImpl* doc, TidyOptionId optId )
     TidyDocFree( doc, dupdecl );
 }
 
-static Bool OptionValueIdentical( const TidyOptionImpl* option,
+static Bool OptionValueIdentical( TidyOption option,
                                   const TidyOptionValue* val1,
                                   const TidyOptionValue* val2 )
 {
@@ -474,7 +474,7 @@ static Bool NeedReparseTagDecls( const TidyOptionValue* current,
 {
     Bool ret = no;
     uint ixVal;
-    const TidyOptionImpl* option = option_defs;
+    TidyOption option = option_defs;
     *changedUserTags = tagtype_null;
 
     for ( ixVal=0; ixVal < N_TIDY_OPTIONS; ++option, ++ixVal )
@@ -501,7 +501,7 @@ static Bool NeedReparseTagDecls( const TidyOptionValue* current,
     return ret;
 }
 
-static void ReparseTagDecls( TidyDocImpl* doc, uint changedUserTags  )
+static void ReparseTagDecls( TidyDoc doc, uint changedUserTags  )
 {
 #define REPARSE_USERTAGS(USERTAGOPTION,USERTAGTYPE) \
     if ( changedUserTags & USERTAGTYPE ) \
@@ -515,10 +515,10 @@ static void ReparseTagDecls( TidyDocImpl* doc, uint changedUserTags  )
     REPARSE_USERTAGS(TidyPreTags,tagtype_pre);
 }
 
-void TY_(ResetConfigToDefault)( TidyDocImpl* doc )
+void TY_(ResetConfigToDefault)( TidyDoc doc )
 {
     uint ixVal;
-    const TidyOptionImpl* option = option_defs;
+    TidyOption option = option_defs;
     TidyOptionValue* value = &doc->config.value[ 0 ];
     for ( ixVal=0; ixVal < N_TIDY_OPTIONS; ++option, ++ixVal )
     {
@@ -530,10 +530,10 @@ void TY_(ResetConfigToDefault)( TidyDocImpl* doc )
     TY_(FreeDeclaredTags)( doc, tagtype_null );
 }
 
-void TY_(TakeConfigSnapshot)( TidyDocImpl* doc )
+void TY_(TakeConfigSnapshot)( TidyDoc doc )
 {
     uint ixVal;
-    const TidyOptionImpl* option = option_defs;
+    TidyOption option = option_defs;
     const TidyOptionValue* value = &doc->config.value[ 0 ];
     TidyOptionValue* snap  = &doc->config.snapshot[ 0 ];
 
@@ -545,10 +545,10 @@ void TY_(TakeConfigSnapshot)( TidyDocImpl* doc )
     }
 }
 
-void TY_(ResetConfigToSnapshot)( TidyDocImpl* doc )
+void TY_(ResetConfigToSnapshot)( TidyDoc doc )
 {
     uint ixVal;
-    const TidyOptionImpl* option = option_defs;
+    TidyOption option = option_defs;
     TidyOptionValue* value = &doc->config.value[ 0 ];
     const TidyOptionValue* snap  = &doc->config.snapshot[ 0 ];
     uint changedUserTags;
@@ -564,12 +564,12 @@ void TY_(ResetConfigToSnapshot)( TidyDocImpl* doc )
         ReparseTagDecls( doc, changedUserTags );
 }
 
-void TY_(CopyConfig)( TidyDocImpl* docTo, TidyDocImpl* docFrom )
+void TY_(CopyConfig)( TidyDoc docTo, TidyDoc docFrom )
 {
     if ( docTo != docFrom )
     {
         uint ixVal;
-        const TidyOptionImpl* option = option_defs;
+        TidyOption option = option_defs;
         const TidyOptionValue* from = &docFrom->config.value[ 0 ];
         TidyOptionValue* to   = &docTo->config.value[ 0 ];
         uint changedUserTags;
@@ -592,32 +592,32 @@ void TY_(CopyConfig)( TidyDocImpl* docTo, TidyDocImpl* docFrom )
 #ifdef _DEBUG
 
 /* Debug accessor functions will be type-safe and assert option type match */
-ulong   TY_(_cfgGet)( TidyDocImpl* doc, TidyOptionId optId )
+ulong   TY_(_cfgGet)( TidyDoc doc, TidyOptionId optId )
 {
   assert( optId < N_TIDY_OPTIONS );
   return doc->config.value[ optId ].v;
 }
 
-Bool    TY_(_cfgGetBool)( TidyDocImpl* doc, TidyOptionId optId )
+Bool    TY_(_cfgGetBool)( TidyDoc doc, TidyOptionId optId )
 {
   ulong val = TY_(_cfgGet)( doc, optId );
-  const TidyOptionImpl* opt = &option_defs[ optId ];
+  TidyOption opt = &option_defs[ optId ];
   assert( opt && opt->type == TidyBoolean );
   return (Bool) val;
 }
 
-TidyTriState    TY_(_cfgGetAutoBool)( TidyDocImpl* doc, TidyOptionId optId )
+TidyTriState    TY_(_cfgGetAutoBool)( TidyDoc doc, TidyOptionId optId )
 {
   ulong val = TY_(_cfgGet)( doc, optId );
-  const TidyOptionImpl* opt = &option_defs[ optId ];
+  TidyOption opt = &option_defs[ optId ];
   assert( opt && opt->type == TidyInteger
           && opt->parser == ParseAutoBool );
   return (TidyTriState) val;
 }
 
-ctmbstr TY_(_cfgGetString)( TidyDocImpl* doc, TidyOptionId optId )
+ctmbstr TY_(_cfgGetString)( TidyDoc doc, TidyOptionId optId )
 {
-  const TidyOptionImpl* opt;
+  TidyOption opt;
 
   assert( optId < N_TIDY_OPTIONS );
   opt = &option_defs[ optId ];
@@ -629,7 +629,7 @@ ctmbstr TY_(_cfgGetString)( TidyDocImpl* doc, TidyOptionId optId )
 
 #if 0
 /* for use with Gnu Emacs */
-void SetEmacsFilename( TidyDocImpl* doc, ctmbstr filename )
+void SetEmacsFilename( TidyDoc doc, ctmbstr filename )
 {
     SetOptionValue( doc, TidyEmacsFile, filename );
 }
@@ -707,7 +707,7 @@ static uint NextProperty( TidyConfigImpl* config )
  work on systems that support getpwnam(userid), 
  namely Unix/Linux.
 */
-static ctmbstr ExpandTilde( TidyDocImpl* doc, ctmbstr filename )
+static ctmbstr ExpandTilde( TidyDoc doc, ctmbstr filename )
 {
     char *home_dir = NULL;
 
@@ -764,7 +764,7 @@ static ctmbstr ExpandTilde( TidyDocImpl* doc, ctmbstr filename )
 
 Bool TIDY_CALL tidyFileExists( TidyDoc tdoc, ctmbstr filename )
 {
-  TidyDocImpl* doc = tidyDocToImpl( tdoc );
+  TidyDoc doc = tidyDocToImpl( tdoc );
   ctmbstr fname = (tmbstr) ExpandTilde( doc, filename );
 #ifndef NO_ACCESS_SUPPORT
   Bool exists = ( access(fname, 0) == 0 );
@@ -786,14 +786,14 @@ Bool TIDY_CALL tidyFileExists( TidyDoc tdoc, ctmbstr filename )
 #define TIDY_MAX_NAME 64
 #endif
 
-int TY_(ParseConfigFile)( TidyDocImpl* doc, ctmbstr file )
+int TY_(ParseConfigFile)( TidyDoc doc, ctmbstr file )
 {
     return TY_(ParseConfigFileEnc)( doc, file, "ascii" );
 }
 
 /* open the file and parse its contents
 */
-int TY_(ParseConfigFileEnc)( TidyDocImpl* doc, ctmbstr file, ctmbstr charenc )
+int TY_(ParseConfigFileEnc)( TidyDoc doc, ctmbstr file, ctmbstr charenc )
 {
     uint opterrs = doc->optionErrors;
     tmbstr fname = (tmbstr) ExpandTilde( doc, file );
@@ -829,7 +829,7 @@ int TY_(ParseConfigFileEnc)( TidyDocImpl* doc, ctmbstr file, ctmbstr charenc )
 
             if ( c == ':' )
             {
-                const TidyOptionImpl* option = TY_(lookupOption)( name );
+                TidyOption option = TY_(lookupOption)( name );
                 c = AdvanceChar( cfg );
                 if ( option )
                     option->parser( doc, option );
@@ -898,9 +898,9 @@ int TY_(ParseConfigFileEnc)( TidyDocImpl* doc, ctmbstr file, ctmbstr charenc )
 /* returns false if unknown option, missing parameter,
 ** or option doesn't use parameter
 */
-Bool TY_(ParseConfigOption)( TidyDocImpl* doc, ctmbstr optnam, ctmbstr optval )
+Bool TY_(ParseConfigOption)( TidyDoc doc, ctmbstr optnam, ctmbstr optval )
 {
-    const TidyOptionImpl* option = TY_(lookupOption)( optnam );
+    TidyOption option = TY_(lookupOption)( optnam );
     Bool status = ( option != NULL );
     if ( !status )
     {
@@ -919,9 +919,9 @@ Bool TY_(ParseConfigOption)( TidyDocImpl* doc, ctmbstr optnam, ctmbstr optval )
 /* returns false if unknown option, missing parameter,
 ** or option doesn't use parameter
 */
-Bool TY_(ParseConfigValue)( TidyDocImpl* doc, TidyOptionId optId, ctmbstr optval )
+Bool TY_(ParseConfigValue)( TidyDoc doc, TidyOptionId optId, ctmbstr optval )
 {
-    const TidyOptionImpl* option = option_defs + optId;
+    TidyOption option = option_defs + optId;
     Bool status = ( optId < N_TIDY_OPTIONS && optval != NULL );
 
     if ( !status )
@@ -948,7 +948,7 @@ Bool TY_(ParseConfigValue)( TidyDocImpl* doc, TidyOptionId optId, ctmbstr optval
 
 
 /* ensure that char encodings are self consistent */
-Bool  TY_(AdjustCharEncoding)( TidyDocImpl* doc, int encoding )
+Bool  TY_(AdjustCharEncoding)( TidyDoc doc, int encoding )
 {
     int outenc = -1;
     int inenc = -1;
@@ -1011,7 +1011,7 @@ Bool  TY_(AdjustCharEncoding)( TidyDocImpl* doc, int encoding )
 }
 
 /* ensure that config is self consistent */
-void AdjustConfig( TidyDocImpl* doc )
+void AdjustConfig( TidyDoc doc )
 {
     if ( cfgBool(doc, TidyEncloseBlockText) )
         TY_(SetOptionBool)( doc, TidyEncloseBodyText, yes );
@@ -1082,7 +1082,7 @@ void AdjustConfig( TidyDocImpl* doc )
 }
 
 /* unsigned integers */
-Bool ParseInt( TidyDocImpl* doc, const TidyOptionImpl* entry )
+Bool ParseInt( TidyDoc doc, TidyOption entry )
 {
     ulong number = 0;
     Bool digits = no;
@@ -1104,8 +1104,8 @@ Bool ParseInt( TidyDocImpl* doc, const TidyOptionImpl* entry )
 }
 
 /* true/false or yes/no or 0/1 or "auto" only looks at 1st char */
-static Bool ParseTriState( TidyTriState theState, TidyDocImpl* doc,
-                           const TidyOptionImpl* entry, ulong* flag )
+static Bool ParseTriState( TidyTriState theState, TidyDoc doc,
+                           TidyOption entry, ulong* flag )
 {
     TidyConfigImpl* cfg = &doc->config;
     tchar c = SkipWhite( cfg );
@@ -1126,7 +1126,7 @@ static Bool ParseTriState( TidyTriState theState, TidyDocImpl* doc,
 }
 
 /* cr, lf or crlf */
-Bool ParseNewline( TidyDocImpl* doc, const TidyOptionImpl* entry )
+Bool ParseNewline( TidyDoc doc, TidyOption entry )
 {
     int nl = -1;
     tmbchar work[ 16 ] = {0};
@@ -1155,7 +1155,7 @@ Bool ParseNewline( TidyDocImpl* doc, const TidyOptionImpl* entry )
     return ( nl >= TidyLF && nl <= TidyCR );
 }
 
-Bool ParseBool( TidyDocImpl* doc, const TidyOptionImpl* entry )
+Bool ParseBool( TidyDoc doc, TidyOption entry )
 {
     ulong flag = 0;
     Bool status = ParseTriState( TidyNoState, doc, entry, &flag );
@@ -1164,7 +1164,7 @@ Bool ParseBool( TidyDocImpl* doc, const TidyOptionImpl* entry )
     return status;
 }
 
-Bool ParseAutoBool( TidyDocImpl* doc, const TidyOptionImpl* entry )
+Bool ParseAutoBool( TidyDoc doc, TidyOption entry )
 {
     ulong flag = 0;
     Bool status = ParseTriState( TidyAutoState, doc, entry, &flag );
@@ -1174,7 +1174,7 @@ Bool ParseAutoBool( TidyDocImpl* doc, const TidyOptionImpl* entry )
 }
 
 /* a string excluding whitespace */
-Bool ParseName( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseName( TidyDoc doc, TidyOption option )
 {
     tmbchar buf[ 1024 ] = {0};
     uint i = 0;
@@ -1195,7 +1195,7 @@ Bool ParseName( TidyDocImpl* doc, const TidyOptionImpl* option )
 }
 
 /* #508936 - CSS class naming for -clean option */
-Bool ParseCSS1Selector( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseCSS1Selector( TidyDoc doc, TidyOption option )
 {
     char buf[256] = {0};
     uint i = 0;
@@ -1229,7 +1229,7 @@ Bool ParseCSS1Selector( TidyDocImpl* doc, const TidyOptionImpl* option )
  * Sets the indent character to a tab if on, and set indent space count to 1
  * and sets indent character to a space if off.
 \*/
-Bool ParseTabs( TidyDocImpl* doc, const TidyOptionImpl* entry )
+Bool ParseTabs( TidyDoc doc, TidyOption entry )
 {
     ulong flag = 0;
     Bool status = ParseTriState( TidyNoState, doc, entry, &flag );
@@ -1247,7 +1247,7 @@ Bool ParseTabs( TidyDocImpl* doc, const TidyOptionImpl* entry )
 
 
 /* Coordinates Config update and Tags data */
-static void DeclareUserTag( TidyDocImpl* doc, TidyOptionId optId,
+static void DeclareUserTag( TidyDoc doc, TidyOptionId optId,
                             UserTagType tagType, ctmbstr name )
 {
   ctmbstr prvval = cfgStr( doc, optId );
@@ -1268,7 +1268,7 @@ static void DeclareUserTag( TidyDocImpl* doc, TidyOptionId optId,
 }
 
 /* a space or comma separated list of tag names */
-Bool ParseTagNames( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseTagNames( TidyDoc doc, TidyOption option )
 {
     TidyConfigImpl* cfg = &doc->config;
     tmbchar buf[1024];
@@ -1355,7 +1355,7 @@ Bool ParseTagNames( TidyDocImpl* doc, const TidyOptionImpl* option )
 /* a string including whitespace */
 /* munges whitespace sequences */
 
-Bool ParseString( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseString( TidyDoc doc, TidyOption option )
 {
     TidyConfigImpl* cfg = &doc->config;
     tmbchar buf[8192];
@@ -1397,7 +1397,7 @@ Bool ParseString( TidyDocImpl* doc, const TidyOptionImpl* option )
     return yes;
 }
 
-Bool ParseCharEnc( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseCharEnc( TidyDoc doc, TidyOption option )
 {
     tmbchar buf[64] = {0};
     uint i = 0;
@@ -1434,7 +1434,7 @@ Bool ParseCharEnc( TidyDocImpl* doc, const TidyOptionImpl* option )
 }
 
 
-int TY_(CharEncodingId)( TidyDocImpl* ARG_UNUSED(doc), ctmbstr charenc )
+int TY_(CharEncodingId)( TidyDoc ARG_UNUSED(doc), ctmbstr charenc )
 {
     int enc = TY_(GetCharEncodingFromOptName)( charenc );
 
@@ -1477,7 +1477,7 @@ ctmbstr TY_(CharEncodingOptName)( int encoding )
 
       "-//ACME//DTD HTML 3.14159//EN"
 */
-Bool ParseDocType( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseDocType( TidyDoc doc, TidyOption option )
 {
     tmbchar buf[ 32 ] = {0};
     uint i = 0;
@@ -1528,7 +1528,7 @@ Bool ParseDocType( TidyDocImpl* doc, const TidyOptionImpl* option )
     return status;
 }
 
-Bool ParseRepeatAttr( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseRepeatAttr( TidyDoc doc, TidyOption option )
 {
     Bool status = yes;
     tmbchar buf[64] = {0};
@@ -1556,7 +1556,7 @@ Bool ParseRepeatAttr( TidyDocImpl* doc, const TidyOptionImpl* option )
     return status;
 }
 
-Bool ParseSorter( TidyDocImpl* doc, const TidyOptionImpl* option )
+Bool ParseSorter( TidyDoc doc, TidyOption option )
 {
     Bool status = yes;
     tmbchar buf[64] = {0};
@@ -1587,7 +1587,7 @@ Bool ParseSorter( TidyDocImpl* doc, const TidyOptionImpl* option )
 /* Use TidyOptionId as iterator.
 ** Send index of 1st option after TidyOptionUnknown as start of list.
 */
-TidyIterator TY_(getOptionList)( TidyDocImpl* ARG_UNUSED(doc) )
+TidyIterator TY_(getOptionList)( TidyDoc ARG_UNUSED(doc) )
 {
     return (TidyIterator) (size_t)1;
 }
@@ -1595,10 +1595,10 @@ TidyIterator TY_(getOptionList)( TidyDocImpl* ARG_UNUSED(doc) )
 /* Check if this item is last valid option.
 ** If so, zero out iterator.
 */
-const TidyOptionImpl*  TY_(getNextOption)( TidyDocImpl* ARG_UNUSED(doc),
+TidyOption  TY_(getNextOption)( TidyDoc ARG_UNUSED(doc),
                                            TidyIterator* iter )
 {
-  const TidyOptionImpl* option = NULL;
+  TidyOption option = NULL;
   size_t optId;
   assert( iter != NULL );
   optId = (size_t) *iter;
@@ -1613,7 +1613,7 @@ const TidyOptionImpl*  TY_(getNextOption)( TidyDocImpl* ARG_UNUSED(doc),
 
 /* Use a 1-based array index as iterator: 0 == end-of-list
 */
-TidyIterator TY_(getOptionPickList)( const TidyOptionImpl* option )
+TidyIterator TY_(getOptionPickList)( TidyOption option )
 {
     size_t ix = 0;
     if ( option && option->pickList )
@@ -1621,7 +1621,7 @@ TidyIterator TY_(getOptionPickList)( const TidyOptionImpl* option )
     return (TidyIterator) ix;
 }
 
-ctmbstr      TY_(getNextOptionPick)( const TidyOptionImpl* option,
+ctmbstr      TY_(getNextOptionPick)( TidyOption option,
                                      TidyIterator* iter )
 {
     size_t ix;
@@ -1635,7 +1635,7 @@ ctmbstr      TY_(getNextOptionPick)( const TidyOptionImpl* option,
     return val;
 }
 
-static int  WriteOptionString( const TidyOptionImpl* option,
+static int  WriteOptionString( TidyOption option,
                                ctmbstr sval, StreamOut* out )
 {
   ctmbstr cp = option->name;
@@ -1650,20 +1650,20 @@ static int  WriteOptionString( const TidyOptionImpl* option,
   return 0;
 }
 
-static int  WriteOptionInt( const TidyOptionImpl* option, uint ival, StreamOut* out )
+static int  WriteOptionInt( TidyOption option, uint ival, StreamOut* out )
 {
   tmbchar sval[ 32 ] = {0};
   TY_(tmbsnprintf)(sval, sizeof(sval), "%u", ival );
   return WriteOptionString( option, sval, out );
 }
 
-static int  WriteOptionBool( const TidyOptionImpl* option, Bool bval, StreamOut* out )
+static int  WriteOptionBool( TidyOption option, Bool bval, StreamOut* out )
 {
   ctmbstr sval = bval ? "yes" : "no";
   return WriteOptionString( option, sval, out );
 }
 
-static int  WriteOptionPick( const TidyOptionImpl* option, uint ival, StreamOut* out )
+static int  WriteOptionPick( TidyOption option, uint ival, StreamOut* out )
 {
     uint ix;
     const ctmbstr* val = option->pickList;
@@ -1674,17 +1674,17 @@ static int  WriteOptionPick( const TidyOptionImpl* option, uint ival, StreamOut*
     return -1;
 }
 
-Bool  TY_(ConfigDiffThanSnapshot)( TidyDocImpl* doc )
+Bool  TY_(ConfigDiffThanSnapshot)( TidyDoc doc )
 {
   int diff = memcmp( &doc->config.value, &doc->config.snapshot,
                      N_TIDY_OPTIONS * sizeof(uint) );
   return ( diff != 0 );
 }
 
-Bool  TY_(ConfigDiffThanDefault)( TidyDocImpl* doc )
+Bool  TY_(ConfigDiffThanDefault)( TidyDoc doc )
 {
   Bool diff = no;
-  const TidyOptionImpl* option = option_defs + 1;
+  TidyOption option = option_defs + 1;
   const TidyOptionValue* val = doc->config.value;
   for ( /**/; !diff && option && option->name; ++option, ++val )
   {
@@ -1694,10 +1694,10 @@ Bool  TY_(ConfigDiffThanDefault)( TidyDocImpl* doc )
 }
 
 
-static int  SaveConfigToStream( TidyDocImpl* doc, StreamOut* out )
+static int  SaveConfigToStream( TidyDoc doc, StreamOut* out )
 {
     int rc = 0;
-    const TidyOptionImpl* option;
+    TidyOption option;
     for ( option=option_defs+1; 0==rc && option && option->name; ++option )
     {
         const TidyOptionValue* val = &doc->config.value[ option->id ];
@@ -1751,7 +1751,7 @@ static int  SaveConfigToStream( TidyDocImpl* doc, StreamOut* out )
     return rc;
 }
 
-int  TY_(SaveConfigFile)( TidyDocImpl* doc, ctmbstr cfgfil )
+int  TY_(SaveConfigFile)( TidyDoc doc, ctmbstr cfgfil )
 {
     int status = -1;
     StreamOut* out = NULL;
@@ -1768,7 +1768,7 @@ int  TY_(SaveConfigFile)( TidyDocImpl* doc, ctmbstr cfgfil )
     return status;
 }
 
-int  TY_(SaveConfigSink)( TidyDocImpl* doc, TidyOutputSink* sink )
+int  TY_(SaveConfigSink)( TidyDoc doc, TidyOutputSink* sink )
 {
     uint outenc = cfg( doc, TidyOutCharEncoding );
     uint nl = cfg( doc, TidyNewline );

--- a/src/config.h
+++ b/src/config.h
@@ -25,10 +25,7 @@
 #include "tidy.h"
 #include "streamio.h"
 
-struct _tidy_option;
-typedef struct _tidy_option TidyOptionImpl;
-
-typedef Bool (ParseProperty)( TidyDocImpl* doc, const TidyOptionImpl* opt );
+typedef Bool (ParseProperty)( TidyDoc doc, TidyOption opt );
 
 struct _tidy_option
 {
@@ -69,64 +66,64 @@ typedef struct {
 } TidyOptionDoc;
 
 
-const TidyOptionImpl* TY_(lookupOption)( ctmbstr optnam );
-const TidyOptionImpl* TY_(getOption)( TidyOptionId optId );
+TidyOption TY_(lookupOption)( ctmbstr optnam );
+TidyOption TY_(getOption)( TidyOptionId optId );
 
-TidyIterator TY_(getOptionList)( TidyDocImpl* doc );
-const TidyOptionImpl* TY_(getNextOption)( TidyDocImpl* doc, TidyIterator* iter );
+TidyIterator TY_(getOptionList)( TidyDoc doc );
+TidyOption TY_(getNextOption)( TidyDoc doc, TidyIterator* iter );
 
-TidyIterator TY_(getOptionPickList)( const TidyOptionImpl* option );
-ctmbstr TY_(getNextOptionPick)( const TidyOptionImpl* option, TidyIterator* iter );
+TidyIterator TY_(getOptionPickList)( TidyOption option );
+ctmbstr TY_(getNextOptionPick)( TidyOption option, TidyIterator* iter );
 
 const TidyOptionDoc* TY_(OptGetDocDesc)( TidyOptionId optId );
 
-void TY_(InitConfig)( TidyDocImpl* doc );
-void TY_(FreeConfig)( TidyDocImpl* doc );
+void TY_(InitConfig)( TidyDoc doc );
+void TY_(FreeConfig)( TidyDoc doc );
 
-/* Bool SetOptionValue( TidyDocImpl* doc, TidyOptionId optId, ctmbstr val ); */
-Bool TY_(SetOptionInt)( TidyDocImpl* doc, TidyOptionId optId, ulong val );
-Bool TY_(SetOptionBool)( TidyDocImpl* doc, TidyOptionId optId, Bool val );
+/* Bool SetOptionValue( TidyDoc doc, TidyOptionId optId, ctmbstr val ); */
+Bool TY_(SetOptionInt)( TidyDoc doc, TidyOptionId optId, ulong val );
+Bool TY_(SetOptionBool)( TidyDoc doc, TidyOptionId optId, Bool val );
 
-Bool TY_(ResetOptionToDefault)( TidyDocImpl* doc, TidyOptionId optId );
-void TY_(ResetConfigToDefault)( TidyDocImpl* doc );
-void TY_(TakeConfigSnapshot)( TidyDocImpl* doc );
-void TY_(ResetConfigToSnapshot)( TidyDocImpl* doc );
+Bool TY_(ResetOptionToDefault)( TidyDoc doc, TidyOptionId optId );
+void TY_(ResetConfigToDefault)( TidyDoc doc );
+void TY_(TakeConfigSnapshot)( TidyDoc doc );
+void TY_(ResetConfigToSnapshot)( TidyDoc doc );
 
-void TY_(CopyConfig)( TidyDocImpl* docTo, TidyDocImpl* docFrom );
+void TY_(CopyConfig)( TidyDoc docTo, TidyDoc docFrom );
 
-int  TY_(ParseConfigFile)( TidyDocImpl* doc, ctmbstr cfgfil );
-int  TY_(ParseConfigFileEnc)( TidyDocImpl* doc,
+int  TY_(ParseConfigFile)( TidyDoc doc, ctmbstr cfgfil );
+int  TY_(ParseConfigFileEnc)( TidyDoc doc,
                               ctmbstr cfgfil, ctmbstr charenc );
 
-int  TY_(SaveConfigFile)( TidyDocImpl* doc, ctmbstr cfgfil );
-int  TY_(SaveConfigSink)( TidyDocImpl* doc, TidyOutputSink* sink );
+int  TY_(SaveConfigFile)( TidyDoc doc, ctmbstr cfgfil );
+int  TY_(SaveConfigSink)( TidyDoc doc, TidyOutputSink* sink );
 
 /* returns false if unknown option, missing parameter, or
    option doesn't use parameter
 */
-Bool  TY_(ParseConfigOption)( TidyDocImpl* doc, ctmbstr optnam, ctmbstr optVal );
-Bool  TY_(ParseConfigValue)( TidyDocImpl* doc, TidyOptionId optId, ctmbstr optVal );
+Bool  TY_(ParseConfigOption)( TidyDoc doc, ctmbstr optnam, ctmbstr optVal );
+Bool  TY_(ParseConfigValue)( TidyDoc doc, TidyOptionId optId, ctmbstr optVal );
 
 /* ensure that char encodings are self consistent */
-Bool  TY_(AdjustCharEncoding)( TidyDocImpl* doc, int encoding );
+Bool  TY_(AdjustCharEncoding)( TidyDoc doc, int encoding );
 
-Bool  TY_(ConfigDiffThanDefault)( TidyDocImpl* doc );
-Bool  TY_(ConfigDiffThanSnapshot)( TidyDocImpl* doc );
+Bool  TY_(ConfigDiffThanDefault)( TidyDoc doc );
+Bool  TY_(ConfigDiffThanSnapshot)( TidyDoc doc );
 
-int TY_(CharEncodingId)( TidyDocImpl* doc, ctmbstr charenc );
+int TY_(CharEncodingId)( TidyDoc doc, ctmbstr charenc );
 ctmbstr TY_(CharEncodingName)( int encoding );
 ctmbstr TY_(CharEncodingOptName)( int encoding );
 
-/* void SetEmacsFilename( TidyDocImpl* doc, ctmbstr filename ); */
+/* void SetEmacsFilename( TidyDoc doc, ctmbstr filename ); */
 
 
 #ifdef _DEBUG
 
 /* Debug lookup functions will be type-safe and assert option type match */
-ulong   TY_(_cfgGet)( TidyDocImpl* doc, TidyOptionId optId );
-Bool    TY_(_cfgGetBool)( TidyDocImpl* doc, TidyOptionId optId );
-TidyTriState TY_(_cfgGetAutoBool)( TidyDocImpl* doc, TidyOptionId optId );
-ctmbstr TY_(_cfgGetString)( TidyDocImpl* doc, TidyOptionId optId );
+ulong   TY_(_cfgGet)( TidyDoc doc, TidyOptionId optId );
+Bool    TY_(_cfgGetBool)( TidyDoc doc, TidyOptionId optId );
+TidyTriState TY_(_cfgGetAutoBool)( TidyDoc doc, TidyOptionId optId );
+ctmbstr TY_(_cfgGetString)( TidyDoc doc, TidyOptionId optId );
 
 #define cfg(doc, id)            TY_(_cfgGet)( (doc), (id) )
 #define cfgBool(doc, id)        TY_(_cfgGetBool)( (doc), (id) )

--- a/src/forward.h
+++ b/src/forward.h
@@ -28,21 +28,11 @@ typedef struct _StreamIn StreamIn;
 struct _StreamOut;
 typedef struct _StreamOut StreamOut;
 
-struct _TidyDocImpl;
-typedef struct _TidyDocImpl TidyDocImpl;
-
-
 struct _Dict;
 typedef struct _Dict Dict;
 
 struct _Attribute;
 typedef struct _Attribute Attribute;
-
-struct _AttVal;
-typedef struct _AttVal AttVal;
-
-struct _Node;
-typedef struct _Node Node;
 
 struct _IStack;
 typedef struct _IStack IStack;

--- a/src/gdoc.c
+++ b/src/gdoc.c
@@ -57,11 +57,11 @@
 /*
   Extricate "element", replace it by its content and delete it.
 */
-static void DiscardContainer( TidyDocImpl* doc, Node *element, Node **pnode)
+static void DiscardContainer( TidyDoc doc, TidyNode element, TidyNode *pnode)
 {
     if (element->content)
     {
-        Node *node, *parent = element->parent;
+        TidyNode node, parent = element->parent;
 
         element->last->next = element->next;
 
@@ -94,9 +94,9 @@ static void DiscardContainer( TidyDocImpl* doc, Node *element, Node **pnode)
     }
 }
 
-static void CleanNode( TidyDocImpl* doc, Node *node )
+static void CleanNode( TidyDoc doc, TidyNode node )
 {
-    Node *child, *next;
+    TidyNode child, next;
 
     if (node->content)
     {
@@ -114,7 +114,7 @@ static void CleanNode( TidyDocImpl* doc, Node *node )
                     DiscardContainer( doc, child, &next);
                 else if (nodeIsA(child) && !child->content)
                  {
-                    AttVal *id = TY_(GetAttrByName)( child, "name" );
+                    TidyAttr id = TY_(GetAttrByName)( child, "name" );
 
                     if (id)
                         TY_(RepairAttrValue)( doc, child->parent, "id", id->value );
@@ -134,13 +134,13 @@ static void CleanNode( TidyDocImpl* doc, Node *node )
 }
 
 /* insert meta element to force browser to recognize doc as UTF8 */
-static void SetUTF8( TidyDocImpl* doc )
+static void SetUTF8( TidyDoc doc )
 {
-    Node *head = TY_(FindHEAD)( doc );
+    TidyNode head = TY_(FindHEAD)( doc );
 
     if (head)
     {
-        Node *node = TY_(InferredTag)(doc, TidyTag_META);
+        TidyNode node = TY_(InferredTag)(doc, TidyTag_META);
         TY_(AddAttribute)( doc, node, "http-equiv", "Content-Type" );
         TY_(AddAttribute)( doc, node, "content", "text/html; charset=UTF-8" );
         TY_(InsertNodeAtStart)( head, node );
@@ -155,7 +155,7 @@ static void SetUTF8( TidyDocImpl* doc )
     - replace <a name=...></a> by id on parent element
     - strip empty <p> elements
 */
-void TY_(CleanGoogleDocument)( TidyDocImpl* doc )
+void TY_(CleanGoogleDocument)( TidyDoc doc )
 {
     /* placeholder.  CleanTree()/CleanNode() will not
     ** zap root element 

--- a/src/gdoc.h
+++ b/src/gdoc.h
@@ -14,6 +14,6 @@
 
 */
 
-void TY_(CleanGoogleDocument)( TidyDocImpl* doc );
+void TY_(CleanGoogleDocument)( TidyDoc doc );
 
 #endif /* __GDOC_H__ */

--- a/src/istack.c
+++ b/src/istack.c
@@ -15,9 +15,9 @@
 #endif
 
 /* duplicate attributes */
-AttVal *TY_(DupAttrs)( TidyDocImpl* doc, AttVal *attrs)
+TidyAttr TY_(DupAttrs)( TidyDoc doc, TidyAttr attrs)
 {
-    AttVal *newattrs;
+    TidyAttr newattrs;
 
     if (attrs == NULL)
         return attrs;
@@ -33,7 +33,7 @@ AttVal *TY_(DupAttrs)( TidyDocImpl* doc, AttVal *attrs)
     return newattrs;
 }
 
-static Bool IsNodePushable( Node *node )
+static Bool IsNodePushable( TidyNode node )
 {
     if (node->tag == NULL)
         return no;
@@ -69,7 +69,7 @@ static Bool IsNodePushable( Node *node )
       <p><em>text</em></p>
       <p><em><em>more text</em></em>
 */
-void TY_(PushInline)( TidyDocImpl* doc, Node *node )
+void TY_(PushInline)( TidyDoc doc, TidyNode node )
 {
     Lexer* lexer = doc->lexer;
     IStack *istack;
@@ -102,11 +102,11 @@ void TY_(PushInline)( TidyDocImpl* doc, Node *node )
     ++(lexer->istacksize);
 }
 
-static void PopIStack( TidyDocImpl* doc )
+static void PopIStack( TidyDoc doc )
 {
     Lexer* lexer = doc->lexer;
     IStack *istack;
-    AttVal *av;
+    TidyAttr av;
 
     --(lexer->istacksize);
     istack = &(lexer->istack[lexer->istacksize]);
@@ -121,7 +121,7 @@ static void PopIStack( TidyDocImpl* doc )
     istack->element = NULL; /* remove the freed element */
 }
 
-static void PopIStackUntil( TidyDocImpl* doc, TidyTagId tid )
+static void PopIStackUntil( TidyDoc doc, TidyTagId tid )
 {
     Lexer* lexer = doc->lexer;
     IStack *istack;
@@ -136,7 +136,7 @@ static void PopIStackUntil( TidyDocImpl* doc, TidyTagId tid )
 }
 
 /* pop inline stack */
-void TY_(PopInline)( TidyDocImpl* doc, Node *node )
+void TY_(PopInline)( TidyDoc doc, TidyNode node )
 {
     Lexer* lexer = doc->lexer;
 
@@ -163,7 +163,7 @@ void TY_(PopInline)( TidyDocImpl* doc, Node *node )
     }
 }
 
-Bool TY_(IsPushed)( TidyDocImpl* doc, Node *node )
+Bool TY_(IsPushed)( TidyDoc doc, TidyNode node )
 {
     Lexer* lexer = doc->lexer;
     int i;
@@ -180,7 +180,7 @@ Bool TY_(IsPushed)( TidyDocImpl* doc, Node *node )
 /*
    Test whether the last element on the stack has the same type than "node".
 */
-Bool TY_(IsPushedLast)( TidyDocImpl* doc, Node *element, Node *node )
+Bool TY_(IsPushedLast)( TidyDoc doc, TidyNode element, TidyNode node )
 {
     Lexer* lexer = doc->lexer;
 
@@ -213,7 +213,7 @@ Bool TY_(IsPushedLast)( TidyDocImpl* doc, Node *element, Node *node )
   where it gets tokens from the inline stack rather than
   from the input stream.
 */
-int TY_(InlineDup)( TidyDocImpl* doc, Node* node )
+int TY_(InlineDup)( TidyDoc doc, TidyNode node )
 {
     Lexer* lexer = doc->lexer;
     int n;
@@ -231,16 +231,16 @@ int TY_(InlineDup)( TidyDocImpl* doc, Node* node )
  defer duplicates when entering a table or other
  element where the inlines shouldn't be duplicated
 */
-void TY_(DeferDup)( TidyDocImpl* doc )
+void TY_(DeferDup)( TidyDoc doc )
 {
     doc->lexer->insert = NULL;
     doc->lexer->inode = NULL;
 }
 
-Node *TY_(InsertedToken)( TidyDocImpl* doc )
+TidyNode TY_(InsertedToken)( TidyDoc doc )
 {
     Lexer* lexer = doc->lexer;
-    Node *node;
+    TidyNode node;
     IStack *istack;
     uint n;
 
@@ -303,7 +303,7 @@ Node *TY_(InsertedToken)( TidyDocImpl* doc )
    This function switches the tag positions on the stack,
    returning 'yes' if both were found in the expected order.
 */
-Bool TY_(SwitchInline)( TidyDocImpl* doc, Node* element, Node* node )
+Bool TY_(SwitchInline)( TidyDoc doc, TidyNode element, TidyNode node )
 {
     Lexer* lexer = doc->lexer;
     if ( lexer
@@ -350,7 +350,7 @@ Bool TY_(SwitchInline)( TidyDocImpl* doc, Node* element, Node* node )
   but it may not be the last element, which InlineDup()
   would handle. Return yes, if found and inserted.
 */
-Bool TY_(InlineDup1)( TidyDocImpl* doc, Node* node, Node* element )
+Bool TY_(InlineDup1)( TidyDoc doc, TidyNode node, TidyNode element )
 {
     Lexer* lexer = doc->lexer;
     int n, i;

--- a/src/mappedio.c
+++ b/src/mappedio.c
@@ -273,7 +273,7 @@ static void freeMappedFileSource( TidyInputSource* inp, Bool closeIt )
     TidyFree( fin->allocator, fin );
 }
 
-StreamIn* MappedFileInput ( TidyDocImpl* doc, HANDLE fp, int encoding )
+StreamIn* MappedFileInput ( TidyDoc doc, HANDLE fp, int encoding )
 {
     StreamIn *in = TY_(initStreamIn)( doc, encoding );
     if ( initMappedFileSource( doc->allocator, &in->source, fp ) != 0 )
@@ -286,7 +286,7 @@ StreamIn* MappedFileInput ( TidyDocImpl* doc, HANDLE fp, int encoding )
 }
 
 
-int TY_(DocParseFileWithMappedFile)( TidyDocImpl* doc, ctmbstr filnam ) {
+int TY_(DocParseFileWithMappedFile)( TidyDoc doc, ctmbstr filnam ) {
     int status = -ENOENT;
     HANDLE fin = CreateFileA( filnam, GENERIC_READ, FILE_SHARE_READ, NULL,
                               OPEN_EXISTING, 0, NULL );

--- a/src/mappedio.h
+++ b/src/mappedio.h
@@ -9,7 +9,7 @@
 */
 
 #if defined(_WIN32)
-int TY_(DocParseFileWithMappedFile)( TidyDocImpl* doc, ctmbstr filnam );
+int TY_(DocParseFileWithMappedFile)( TidyDoc doc, ctmbstr filnam );
 #endif
 
 #endif /* __TIDY_MAPPED_IO_H__ */

--- a/src/message.c
+++ b/src/message.c
@@ -151,7 +151,7 @@ static char* LevelPrefix( TidyReportLevel level, char* buf, size_t count )
 ** compares counts to options to see if message
 ** display should go forward.
 */
-static Bool UpdateCount( TidyDocImpl* doc, TidyReportLevel level )
+static Bool UpdateCount( TidyDoc doc, TidyReportLevel level )
 {
   /* keep quiet after <ShowErrors> errors */
   Bool go = ( doc->errors < cfg(doc, TidyShowErrors) );
@@ -189,7 +189,7 @@ static Bool UpdateCount( TidyDocImpl* doc, TidyReportLevel level )
 /* Generates the string indicating the source document position for which
 ** Tidy has generated a message.
 */
-static char* ReportPosition(TidyDocImpl* doc, int line, int col, char* buf, size_t count)
+static char* ReportPosition(TidyDoc doc, int line, int col, char* buf, size_t count)
 {
     *buf = 0;
 
@@ -214,13 +214,13 @@ static char* ReportPosition(TidyDocImpl* doc, int line, int col, char* buf, size
 ** filter routine.
 */
 
-static void messagePos( TidyDocImpl* doc, TidyReportLevel level, uint code,
+static void messagePos( TidyDoc doc, TidyReportLevel level, uint code,
                         int line, int col, ctmbstr msg, va_list args )
 #ifdef __GNUC__
 __attribute__((format(printf, 6, 0)))
 #endif
 ;
-static void messagePos( TidyDocImpl* doc, TidyReportLevel level, uint code,
+static void messagePos( TidyDoc doc, TidyReportLevel level, uint code,
                         int line, int col, ctmbstr msg, va_list args )
 {
     enum { sizeMessageBuf=2048 };
@@ -293,7 +293,7 @@ static void messagePos( TidyDocImpl* doc, TidyReportLevel level, uint code,
 
 /* Reports error at current Lexer line/column. */ 
 static
-void message( TidyDocImpl* doc, TidyReportLevel level, uint code,
+void message( TidyDoc doc, TidyReportLevel level, uint code,
               ctmbstr msg, ... )
 #ifdef __GNUC__
 __attribute__((format(printf, 4, 5)))
@@ -302,8 +302,8 @@ __attribute__((format(printf, 4, 5)))
 
 /* Reports error at node line/column. */ 
 static
-void messageNode( TidyDocImpl* doc, TidyReportLevel level, uint code,
-                  Node* node, ctmbstr msg, ... )
+void messageNode( TidyDoc doc, TidyReportLevel level, uint code,
+                  TidyNode node, ctmbstr msg, ... )
 #ifdef __GNUC__
 __attribute__((format(printf, 5, 6)))
 #endif
@@ -311,7 +311,7 @@ __attribute__((format(printf, 5, 6)))
 
 /* Reports error at given line/column. */ 
 static
-void messageLexer( TidyDocImpl* doc, TidyReportLevel level, uint code,
+void messageLexer( TidyDoc doc, TidyReportLevel level, uint code,
                    ctmbstr msg, ... )
 #ifdef __GNUC__
 __attribute__((format(printf, 4, 5)))
@@ -320,14 +320,14 @@ __attribute__((format(printf, 4, 5)))
 
 /* For general reporting.  Emits nothing if --quiet yes */
 static
-void tidy_out( TidyDocImpl* doc, ctmbstr msg, ... )
+void tidy_out( TidyDoc doc, ctmbstr msg, ... )
 #ifdef __GNUC__
 __attribute__((format(printf, 2, 3)))
 #endif
 ;
 
 
-void message( TidyDocImpl* doc, TidyReportLevel level, uint code,
+void message( TidyDoc doc, TidyReportLevel level, uint code,
               ctmbstr msg, ... )
 {
     va_list args;
@@ -338,7 +338,7 @@ void message( TidyDocImpl* doc, TidyReportLevel level, uint code,
 }
 
 
-void messageLexer( TidyDocImpl* doc, TidyReportLevel level, uint code,
+void messageLexer( TidyDoc doc, TidyReportLevel level, uint code,
                    ctmbstr msg, ... )
 {
     int line = ( doc->lexer ? doc->lexer->lines : 0 );
@@ -350,8 +350,8 @@ void messageLexer( TidyDocImpl* doc, TidyReportLevel level, uint code,
     va_end( args );
 }
 
-void messageNode( TidyDocImpl* doc, TidyReportLevel level, uint code,
-                  Node* node, ctmbstr msg, ... )
+void messageNode( TidyDoc doc, TidyReportLevel level, uint code,
+                  TidyNode node, ctmbstr msg, ... )
 {
     int line = ( node ? node->line :
                  ( doc->lexer ? doc->lexer->lines : 0 ) );
@@ -364,7 +364,7 @@ void messageNode( TidyDocImpl* doc, TidyReportLevel level, uint code,
     va_end( args );
 }
 
-void tidy_out( TidyDocImpl* doc, ctmbstr msg, ... )
+void tidy_out( TidyDoc doc, ctmbstr msg, ... )
 {
     if ( !cfgBool(doc, TidyQuiet) )
     {
@@ -392,12 +392,12 @@ void tidy_out( TidyDocImpl* doc, ctmbstr msg, ... )
     }
 }
 
-void TY_(FileError)( TidyDocImpl* doc, ctmbstr file, TidyReportLevel level )
+void TY_(FileError)( TidyDoc doc, ctmbstr file, TidyReportLevel level )
 {
     message( doc, level, FILE_CANT_OPEN, tidyLocalizedString(FILE_CANT_OPEN), file );
 }
 
-static char* TagToString(Node* tag, char* buf, size_t count)
+static char* TagToString(TidyNode tag, char* buf, size_t count)
 {
     *buf = 0;
     if (tag)
@@ -419,14 +419,14 @@ static char* TagToString(Node* tag, char* buf, size_t count)
 }
 
 /* lexer is not defined when this is called */
-void TY_(ReportUnknownOption)( TidyDocImpl* doc, ctmbstr option )
+void TY_(ReportUnknownOption)( TidyDoc doc, ctmbstr option )
 {
     assert( option != NULL );
     message( doc, TidyConfig, STRING_UNKNOWN_OPTION, tidyLocalizedString(STRING_UNKNOWN_OPTION), option );
 }
 
 /* lexer is not defined when this is called */
-void TY_(ReportBadArgument)( TidyDocImpl* doc, ctmbstr option )
+void TY_(ReportBadArgument)( TidyDoc doc, ctmbstr option )
 {
     assert( option != NULL );
     message( doc, TidyConfig, STRING_MISSING_MALFORMED, tidyLocalizedString(STRING_MISSING_MALFORMED), option );
@@ -458,7 +458,7 @@ static void NtoS(int n, tmbstr str)
     str[n+1] = '\0';
 }
 
-void TY_(ReportEncodingWarning)(TidyDocImpl* doc, uint code, uint encoding)
+void TY_(ReportEncodingWarning)(TidyDoc doc, uint code, uint encoding)
 {
     switch(code)
     {
@@ -471,7 +471,7 @@ void TY_(ReportEncodingWarning)(TidyDocImpl* doc, uint code, uint encoding)
     }
 }
 
-void TY_(ReportEncodingError)(TidyDocImpl* doc, uint code, uint c, Bool discarded)
+void TY_(ReportEncodingError)(TidyDoc doc, uint code, uint c, Bool discarded)
 {
     char buf[ 32 ] = {'\0'};
 
@@ -513,7 +513,7 @@ void TY_(ReportEncodingError)(TidyDocImpl* doc, uint code, uint c, Bool discarde
         messageLexer( doc, TidyWarning, code, fmt, action, buf );
 }
 
-void TY_(ReportEntityError)( TidyDocImpl* doc, uint code, ctmbstr entity,
+void TY_(ReportEntityError)( TidyDoc doc, uint code, ctmbstr entity,
                              int ARG_UNUSED(c) )
 {
     ctmbstr fmt;
@@ -525,7 +525,7 @@ void TY_(ReportEntityError)( TidyDocImpl* doc, uint code, ctmbstr entity,
         messageLexer( doc, TidyWarning, code, fmt, entityname );
 }
 
-void TY_(ReportAttrError)(TidyDocImpl* doc, Node *node, AttVal *av, uint code)
+void TY_(ReportAttrError)(TidyDoc doc, TidyNode node, TidyAttr av, uint code)
 {
     char const *name = "NULL", *value = "NULL";
     char tagdesc[64];
@@ -620,7 +620,7 @@ void TY_(ReportAttrError)(TidyDocImpl* doc, Node *node, AttVal *av, uint code)
     }
 }
 
-void TY_(ReportMissingAttr)( TidyDocImpl* doc, Node* node, ctmbstr name )
+void TY_(ReportMissingAttr)( TidyDoc doc, TidyNode node, ctmbstr name )
 {
     char tagdesc[ 64 ];
     ctmbstr fmt = tidyLocalizedString(MISSING_ATTRIBUTE);
@@ -643,19 +643,19 @@ void TY_(ReportMissingAttr)( TidyDocImpl* doc, Node* node, ctmbstr name )
 * with the cells.
 *********************************************************/
  
-void TY_(DisplayHTMLTableAlgorithm)( TidyDocImpl* doc )
+void TY_(DisplayHTMLTableAlgorithm)( TidyDoc doc )
 {
     tidy_out(doc, "%s", tidyLocalizedString(TEXT_HTML_T_ALGORITHM));
 }
 
-void TY_(ReportAccessWarning)( TidyDocImpl* doc, Node* node, uint code )
+void TY_(ReportAccessWarning)( TidyDoc doc, TidyNode node, uint code )
 {
     ctmbstr fmt = tidyLocalizedString(code);
     doc->badAccess |= BA_WAI;
     messageNode( doc, TidyAccess, code, node, "%s", fmt );
 }
 
-void TY_(ReportAccessError)( TidyDocImpl* doc, Node* node, uint code )
+void TY_(ReportAccessError)( TidyDoc doc, TidyNode node, uint code )
 {
     ctmbstr fmt = tidyLocalizedString(code);
     doc->badAccess |= BA_WAI;
@@ -664,9 +664,9 @@ void TY_(ReportAccessError)( TidyDocImpl* doc, Node* node, uint code )
 
 #endif /* SUPPORT_ACCESSIBILITY_CHECKS */
 
-void TY_(ReportWarning)(TidyDocImpl* doc, Node *element, Node *node, uint code)
+void TY_(ReportWarning)(TidyDoc doc, TidyNode element, TidyNode node, uint code)
 {
-    Node* rpt = (element ? element : node);
+    TidyNode rpt = (element ? element : node);
     ctmbstr fmt = tidyLocalizedString(code);
     char nodedesc[256] = { 0 };
     char elemdesc[256] = { 0 };
@@ -697,9 +697,9 @@ void TY_(ReportWarning)(TidyDocImpl* doc, Node *element, Node *node, uint code)
     }
 }
 
-void TY_(ReportNotice)(TidyDocImpl* doc, Node *element, Node *node, uint code)
+void TY_(ReportNotice)(TidyDoc doc, TidyNode element, TidyNode node, uint code)
 {
-    Node* rpt = ( element ? element : node );
+    TidyNode rpt = ( element ? element : node );
     ctmbstr fmt = tidyLocalizedString(code);
     char nodedesc[256] = { 0 };
     char elemdesc[256] = { 0 };
@@ -722,11 +722,11 @@ void TY_(ReportNotice)(TidyDocImpl* doc, Node *element, Node *node, uint code)
     }
 }
 
-void TY_(ReportError)(TidyDocImpl* doc, Node *element, Node *node, uint code)
+void TY_(ReportError)(TidyDoc doc, TidyNode element, TidyNode node, uint code)
 {
     char nodedesc[ 256 ] = {0};
     char elemdesc[ 256 ] = {0};
-    Node* rpt = ( element ? element : node );
+    TidyNode rpt = ( element ? element : node );
     ctmbstr fmt = tidyLocalizedString(code);
     uint versionEmitted, declared, version;
     ctmbstr extra_string = NULL;
@@ -846,10 +846,10 @@ void TY_(ReportError)(TidyDocImpl* doc, Node *element, Node *node, uint code)
     }
 }
 
-void TY_(ReportFatal)( TidyDocImpl* doc, Node *element, Node *node, uint code)
+void TY_(ReportFatal)( TidyDoc doc, TidyNode element, TidyNode node, uint code)
 {
     char nodedesc[ 256 ] = {0};
-    Node* rpt = ( element ? element : node );
+    TidyNode rpt = ( element ? element : node );
     ctmbstr fmt = tidyLocalizedString(code);
 
     switch ( code )
@@ -874,7 +874,7 @@ void TY_(ReportFatal)( TidyDocImpl* doc, Node *element, Node *node, uint code)
     }
 }
 
-void TY_(ErrorSummary)( TidyDocImpl* doc )
+void TY_(ErrorSummary)( TidyDoc doc )
 {
     ctmbstr encnam = tidyLocalizedString(STRING_SPECIFIED);
     int charenc = cfg( doc, TidyCharEncoding ); 
@@ -1007,23 +1007,23 @@ void TY_(ErrorSummary)( TidyDocImpl* doc )
 }
 
 #if 0
-void TY_(UnknownOption)( TidyDocImpl* doc, char c )
+void TY_(UnknownOption)( TidyDoc doc, char c )
 {
     message( doc, TidyConfig, tidyLocalizedString(STRING_UNRECZD_OPTION), c );
 }
 
-void TY_(UnknownFile)( TidyDocImpl* doc, ctmbstr program, ctmbstr file )
+void TY_(UnknownFile)( TidyDoc doc, ctmbstr program, ctmbstr file )
 {
     message( doc, TidyConfig, tidyLocalizedString(STRING_UNKNOWN_FILE), program, file );
 }
 #endif
 
-void TY_(NeedsAuthorIntervention)( TidyDocImpl* doc )
+void TY_(NeedsAuthorIntervention)( TidyDoc doc )
 {
     tidy_out(doc, "%s", tidyLocalizedString(TEXT_NEEDS_INTERVENTION));
 }
 
-void TY_(GeneralInfo)( TidyDocImpl* doc )
+void TY_(GeneralInfo)( TidyDoc doc )
 {
     if (!cfgBool(doc, TidyShowInfo)) return;
     tidy_out(doc, "%s", tidyLocalizedString(TEXT_GENERAL_INFO));
@@ -1032,7 +1032,7 @@ void TY_(GeneralInfo)( TidyDocImpl* doc )
 
 #if SUPPORT_ACCESSIBILITY_CHECKS
 
-void TY_(AccessibilityHelloMessage)( TidyDocImpl* doc )
+void TY_(AccessibilityHelloMessage)( TidyDoc doc )
 {
     tidy_out(doc, "\n%s\n\n", tidyLocalizedString(STRING_HELLO_ACCESS));
 }
@@ -1040,7 +1040,7 @@ void TY_(AccessibilityHelloMessage)( TidyDocImpl* doc )
 #endif /* SUPPORT_ACCESSIBILITY_CHECKS */
 
 
-void TY_(ReportMarkupVersion)( TidyDocImpl* doc )
+void TY_(ReportMarkupVersion)( TidyDoc doc )
 {
     if (doc->givenDoctype)
     {
@@ -1069,7 +1069,7 @@ void TY_(ReportMarkupVersion)( TidyDocImpl* doc )
     }
 }
 
-void TY_(ReportNumWarnings)( TidyDocImpl* doc )
+void TY_(ReportNumWarnings)( TidyDoc doc )
 {
     if ( doc->warnings > 0 || doc->errors > 0 )
     {

--- a/src/message.c
+++ b/src/message.c
@@ -234,8 +234,7 @@ static void messagePos( TidyDoc doc, TidyReportLevel level, uint code,
         TY_(tmbvsnprintf)(messageBuf, sizeMessageBuf, msg, args);
         if ( doc->mssgFilt )
         {
-            TidyDoc tdoc = tidyImplToDoc( doc );
-            go = doc->mssgFilt( tdoc, level, line, col, messageBuf );
+            go = doc->mssgFilt( doc, level, line, col, messageBuf );
         }
         if ( doc->mssgFilt2 )
         {
@@ -244,16 +243,14 @@ static void messagePos( TidyDoc doc, TidyReportLevel level, uint code,
                the parameters to fill it. For the key string to remain
                consistent, we have to ensure that we only ever return the
                built-in English version of this string. */
-            TidyDoc tdoc = tidyImplToDoc( doc );
-            go = go | doc->mssgFilt2( tdoc, level, line, col, tidyDefaultString(code), args_copy );
+            go = go | doc->mssgFilt2( doc, level, line, col, tidyDefaultString(code), args_copy );
         }
         if ( doc->mssgFilt3 )
         {
             /* mssgFilt3 is intended to allow LibTidy users to localize
                messages via their own means by providing a key string and
                the parameters to fill it. */
-            TidyDoc tdoc = tidyImplToDoc( doc );
-            go = go | doc->mssgFilt3( tdoc, level, line, col, tidyErrorCodeAsString(code), args_copy );
+            go = go | doc->mssgFilt3( doc, level, line, col, tidyErrorCodeAsString(code), args_copy );
         }
     }
 

--- a/src/message.h
+++ b/src/message.h
@@ -27,37 +27,37 @@
 
 ctmbstr TY_(ReleaseDate)(void);
 
-void TY_(ReportUnknownOption)( TidyDocImpl* doc, ctmbstr option );
-void TY_(ReportBadArgument)( TidyDocImpl* doc, ctmbstr option );
-void TY_(NeedsAuthorIntervention)( TidyDocImpl* doc );
+void TY_(ReportUnknownOption)( TidyDoc doc, ctmbstr option );
+void TY_(ReportBadArgument)( TidyDoc doc, ctmbstr option );
+void TY_(NeedsAuthorIntervention)( TidyDoc doc );
 
-void TY_(ReportMarkupVersion)( TidyDocImpl* doc );
-void TY_(ReportNumWarnings)( TidyDocImpl* doc );
+void TY_(ReportMarkupVersion)( TidyDoc doc );
+void TY_(ReportNumWarnings)( TidyDoc doc );
 
-void TY_(GeneralInfo)( TidyDocImpl* doc );
-/* void TY_(UnknownOption)( TidyDocImpl* doc, char c ); */
-/* void TY_(UnknownFile)( TidyDocImpl* doc, ctmbstr program, ctmbstr file ); */
-void TY_(FileError)( TidyDocImpl* doc, ctmbstr file, TidyReportLevel level );
+void TY_(GeneralInfo)( TidyDoc doc );
+/* void TY_(UnknownOption)( TidyDoc doc, char c ); */
+/* void TY_(UnknownFile)( TidyDoc doc, ctmbstr program, ctmbstr file ); */
+void TY_(FileError)( TidyDoc doc, ctmbstr file, TidyReportLevel level );
 
-void TY_(ErrorSummary)( TidyDocImpl* doc );
+void TY_(ErrorSummary)( TidyDoc doc );
 
-void TY_(ReportEncodingWarning)(TidyDocImpl* doc, uint code, uint encoding);
-void TY_(ReportEncodingError)(TidyDocImpl* doc, uint code, uint c, Bool discarded);
-void TY_(ReportEntityError)( TidyDocImpl* doc, uint code, ctmbstr entity, int c );
-void TY_(ReportAttrError)( TidyDocImpl* doc, Node* node, AttVal* av, uint code );
-void TY_(ReportMissingAttr)( TidyDocImpl* doc, Node* node, ctmbstr name );
+void TY_(ReportEncodingWarning)(TidyDoc doc, uint code, uint encoding);
+void TY_(ReportEncodingError)(TidyDoc doc, uint code, uint c, Bool discarded);
+void TY_(ReportEntityError)( TidyDoc doc, uint code, ctmbstr entity, int c );
+void TY_(ReportAttrError)( TidyDoc doc, TidyNode node, TidyAttr av, uint code );
+void TY_(ReportMissingAttr)( TidyDoc doc, TidyNode node, ctmbstr name );
 
 #if SUPPORT_ACCESSIBILITY_CHECKS
 
-void TY_(ReportAccessWarning)( TidyDocImpl* doc, Node* node, uint code );
-void TY_(ReportAccessError)( TidyDocImpl* doc, Node* node, uint code );
+void TY_(ReportAccessWarning)( TidyDoc doc, TidyNode node, uint code );
+void TY_(ReportAccessError)( TidyDoc doc, TidyNode node, uint code );
 
 #endif
 
-void TY_(ReportNotice)(TidyDocImpl* doc, Node *element, Node *node, uint code);
-void TY_(ReportWarning)(TidyDocImpl* doc, Node *element, Node *node, uint code);
-void TY_(ReportError)(TidyDocImpl* doc, Node* element, Node* node, uint code);
-void TY_(ReportFatal)(TidyDocImpl* doc, Node* element, Node* node, uint code);
+void TY_(ReportNotice)(TidyDoc doc, TidyNode element, TidyNode node, uint code);
+void TY_(ReportWarning)(TidyDoc doc, TidyNode element, TidyNode node, uint code);
+void TY_(ReportError)(TidyDoc doc, TidyNode element, TidyNode node, uint code);
+void TY_(ReportFatal)(TidyDoc doc, TidyNode element, TidyNode node, uint code);
 
 
 /**

--- a/src/parser.h
+++ b/src/parser.h
@@ -10,9 +10,9 @@
 
 #include "forward.h"
 
-Bool TY_(CheckNodeIntegrity)(Node *node);
+Bool TY_(CheckNodeIntegrity)(TidyNode node);
 
-Bool TY_(TextNodeEndWithSpace)( Lexer *lexer, Node *node );
+Bool TY_(TextNodeEndWithSpace)( Lexer *lexer, TidyNode node );
 
 /*
  used to determine how attributes
@@ -20,51 +20,51 @@ Bool TY_(TextNodeEndWithSpace)( Lexer *lexer, Node *node );
  this was introduced to deal with
  user defined tags e.g. Cold Fusion
 */
-Bool TY_(IsNewNode)(Node *node);
+Bool TY_(IsNewNode)(TidyNode node);
 
-void TY_(CoerceNode)(TidyDocImpl* doc, Node *node, TidyTagId tid, Bool obsolete, Bool expected);
+void TY_(CoerceNode)(TidyDoc doc, TidyNode node, TidyTagId tid, Bool obsolete, Bool expected);
 
 /* extract a node and its children from a markup tree */
-Node *TY_(RemoveNode)(Node *node);
+TidyNode TY_(RemoveNode)(TidyNode node);
 
 /* remove node from markup tree and discard it */
-Node *TY_(DiscardElement)( TidyDocImpl* doc, Node *element);
+TidyNode TY_(DiscardElement)( TidyDoc doc, TidyNode element);
 
 /* insert node into markup tree as the firt element
  of content of element */
-void TY_(InsertNodeAtStart)(Node *element, Node *node);
+void TY_(InsertNodeAtStart)(TidyNode element, TidyNode node);
 
 /* insert node into markup tree as the last element
  of content of "element" */
-void TY_(InsertNodeAtEnd)(Node *element, Node *node);
+void TY_(InsertNodeAtEnd)(TidyNode element, TidyNode node);
 
 /* insert node into markup tree before element */
-void TY_(InsertNodeBeforeElement)(Node *element, Node *node);
+void TY_(InsertNodeBeforeElement)(TidyNode element, TidyNode node);
 
 /* insert node into markup tree after element */
-void TY_(InsertNodeAfterElement)(Node *element, Node *node);
+void TY_(InsertNodeAfterElement)(TidyNode element, TidyNode node);
 
-Node *TY_(TrimEmptyElement)( TidyDocImpl* doc, Node *element );
-Node* TY_(DropEmptyElements)(TidyDocImpl* doc, Node* node);
+TidyNode TY_(TrimEmptyElement)( TidyDoc doc, TidyNode element );
+TidyNode TY_(DropEmptyElements)(TidyDoc doc, TidyNode node);
 
 
 /* assumes node is a text node */
-Bool TY_(IsBlank)(Lexer *lexer, Node *node);
+Bool TY_(IsBlank)(Lexer *lexer, TidyNode node);
 
-Bool TY_(IsJavaScript)(Node *node);
+Bool TY_(IsJavaScript)(TidyNode node);
 
 /*
   HTML is the top level element
 */
-void TY_(ParseDocument)( TidyDocImpl* doc );
+void TY_(ParseDocument)( TidyDoc doc );
 
 
 
 /*
   XML documents
 */
-Bool TY_(XMLPreserveWhiteSpace)( TidyDocImpl* doc, Node *element );
+Bool TY_(XMLPreserveWhiteSpace)( TidyDoc doc, TidyNode element );
 
-void TY_(ParseXMLDocument)( TidyDocImpl* doc );
+void TY_(ParseXMLDocument)( TidyDoc doc );
 
 #endif /* __PARSER_H__ */

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2181,7 +2181,7 @@ void TY_(PPrintTree)( TidyDoc doc, uint mode, uint indent, TidyNode node )
 
     if (doc->progressCallback)
     {
-        doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line + 1 );
+        doc->progressCallback( doc, node->line, node->column, doc->pprint.line + 1 );
     }
 
 #if !defined(NDEBUG) && defined(_MSC_VER) && defined(DEBUG_PPRINT)
@@ -2466,7 +2466,7 @@ void TY_(PPrintXMLTree)( TidyDoc doc, uint mode, uint indent, TidyNode node )
 
     if (doc->progressCallback)
     {
-        doc->progressCallback( tidyImplToDoc(doc), node->line, node->column, doc->pprint.line + 1 );
+        doc->progressCallback( doc, node->line, node->column, doc->pprint.line + 1 );
     }
     
     if ( node->type == TextNode)

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -22,7 +22,7 @@
 /* #define DEBUG_PPRINT */
 /* #define DEBUG_INDENT */
 #ifdef DEBUG_PPRINT
-extern void dbg_show_node( TidyDocImpl* doc, Node *node, int caller, int indent );
+extern void dbg_show_node( TidyDoc doc, TidyNode node, int caller, int indent );
 #endif
 #ifdef DEBUG_INDENT
 #include "sprtf.h"
@@ -40,13 +40,13 @@ extern void dbg_show_node( TidyDocImpl* doc, Node *node, int caller, int indent 
   start tags and before end tags
 */
 
-static void PPrintAsp( TidyDocImpl* doc, uint indent, Node* node );
-static void PPrintJste( TidyDocImpl* doc, uint indent, Node* node );
-static void PPrintPhp( TidyDocImpl* doc, uint indent, Node* node );
-static int  TextEndsWithNewline( Lexer *lexer, Node *node, uint mode );
-static int  TextStartsWithWhitespace( Lexer *lexer, Node *node, uint start, uint mode );
-static Bool InsideHead( TidyDocImpl* doc, Node *node );
-static Bool ShouldIndent( TidyDocImpl* doc, Node *node );
+static void PPrintAsp( TidyDoc doc, uint indent, TidyNode node );
+static void PPrintJste( TidyDoc doc, uint indent, TidyNode node );
+static void PPrintPhp( TidyDoc doc, uint indent, TidyNode node );
+static int  TextEndsWithNewline( Lexer *lexer, TidyNode node, uint mode );
+static int  TextStartsWithWhitespace( Lexer *lexer, TidyNode node, uint start, uint mode );
+static Bool InsideHead( TidyDoc doc, TidyNode node );
+static Bool ShouldIndent( TidyDoc doc, TidyNode node );
 
 /*\
  * Issue #228 20150715 - macros to access --vertical-space tri state configuration parameter
@@ -73,7 +73,7 @@ void TY_(PPrintSpaces)(void)
 /* #431953 - start RJ Wraplen adjusted for smooth international ride */
 
 #if 0
-uint CWrapLen( TidyDocImpl* doc, uint ind )
+uint CWrapLen( TidyDoc doc, uint ind )
 {
     ctmbstr lang = cfgStr( doc, TidyLanguage );
     uint wraplen = cfg( doc, TidyWrapLen );
@@ -318,7 +318,7 @@ static void InitIndent( TidyIndent* ind )
     ind->attrStringStart = -1;
 }
 
-void TY_(InitPrintBuf)( TidyDocImpl* doc )
+void TY_(InitPrintBuf)( TidyDoc doc )
 {
     TidyClearMemory( &doc->pprint, sizeof(TidyPrintImpl) );
     InitIndent( &doc->pprint.indent[0] );
@@ -327,7 +327,7 @@ void TY_(InitPrintBuf)( TidyDocImpl* doc )
     doc->pprint.line = 0;
 }
 
-void TY_(FreePrintBuf)( TidyDocImpl* doc )
+void TY_(FreePrintBuf)( TidyDoc doc )
 {
     TidyDocFree( doc, doc->pprint.linebuf );
     TY_(InitPrintBuf)( doc );
@@ -383,9 +383,9 @@ static Bool IsWrapInString( TidyPrintImpl* pprint )
              (ind->attrStringStart > 0 && ind->attrStringStart < wrap) );
 }
 
-static Bool HasMixedContent (Node *element)
+static Bool HasMixedContent (TidyNode element)
 {
-    Node * node;
+    TidyNode  node;
 
     if (!element)
         return no;
@@ -415,7 +415,7 @@ static Bool IsWrapInAttrVal( TidyPrintImpl* pprint )
              (ind->attrValStart > 0 && ind->attrValStart < wrap) );
 }
 
-static Bool WantIndent( TidyDocImpl* doc )
+static Bool WantIndent( TidyDoc doc )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool wantIt = GetSpaces(pprint) > 0;
@@ -429,19 +429,19 @@ static Bool WantIndent( TidyDocImpl* doc )
 }
 
 
-static uint  WrapOff( TidyDocImpl* doc )
+static uint  WrapOff( TidyDoc doc )
 {
     uint saveWrap = cfg( doc, TidyWrapLen );
     TY_(SetOptionInt)( doc, TidyWrapLen, 0xFFFFFFFF );  /* very large number */
     return saveWrap;
 }
 
-static void  WrapOn( TidyDocImpl* doc, uint saveWrap )
+static void  WrapOn( TidyDoc doc, uint saveWrap )
 {
     TY_(SetOptionInt)( doc, TidyWrapLen, saveWrap );
 }
 
-static uint  WrapOffCond( TidyDocImpl* doc, Bool onoff )
+static uint  WrapOffCond( TidyDoc doc, Bool onoff )
 {
     if ( onoff )
         return WrapOff( doc );
@@ -482,7 +482,7 @@ static uint AddString( TidyPrintImpl* pprint, ctmbstr str )
 ** but only if indentation would NOT overflow 
 ** the current line.  Otherwise keep previous wrap point.
 */
-static Bool SetWrap( TidyDocImpl* doc, uint indent )
+static Bool SetWrap( TidyDoc doc, uint indent )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool wrap = ( indent + pprint->linelen < cfg(doc, TidyWrapLen) );
@@ -511,7 +511,7 @@ static void CarryOver( int* valTo, int* valFrom, uint wrapPoint )
 }
 
 
-static Bool SetWrapAttr( TidyDocImpl* doc,
+static Bool SetWrapAttr( TidyDoc doc,
                          uint indent, int attrStart, int strStart )
 {
     TidyPrintImpl* pprint = &doc->pprint;
@@ -604,7 +604,7 @@ static void ResetLineAfterWrap( TidyPrintImpl* pprint )
 ** previously saved wrap point.  Shifts unwritten
 ** text in output buffer to beginning of next line.
 */
-static void WrapLine( TidyDocImpl* doc )
+static void WrapLine( TidyDoc doc )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     uint i;
@@ -634,7 +634,7 @@ static void WrapLine( TidyDocImpl* doc )
 ** If combined they overflow output line length, go ahead
 ** and flush output up to the current wrap point.
 */
-static Bool CheckWrapLine( TidyDocImpl* doc )
+static Bool CheckWrapLine( TidyDoc doc )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     if ( GetSpaces(pprint) + pprint->linelen >= cfg(doc, TidyWrapLen) )
@@ -645,7 +645,7 @@ static Bool CheckWrapLine( TidyDocImpl* doc )
     return no;
 }
 
-static Bool CheckWrapIndent( TidyDocImpl* doc, uint indent )
+static Bool CheckWrapIndent( TidyDoc doc, uint indent )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     if ( GetSpaces(pprint) + pprint->linelen >= cfg(doc, TidyWrapLen) )
@@ -663,7 +663,7 @@ static Bool CheckWrapIndent( TidyDocImpl* doc, uint indent )
     return no;
 }
 
-static void WrapAttrVal( TidyDocImpl* doc )
+static void WrapAttrVal( TidyDoc doc )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     uint i;
@@ -689,7 +689,7 @@ static void WrapAttrVal( TidyDocImpl* doc )
     ResetLineAfterWrap( pprint );
 }
 
-static void PFlushLineImpl( TidyDocImpl* doc )
+static void PFlushLineImpl( TidyDoc doc )
 {
     TidyPrintImpl* pprint = &doc->pprint;
 
@@ -713,7 +713,7 @@ static void PFlushLineImpl( TidyDocImpl* doc )
     pprint->linelen = 0;
 }
 
-void TY_(PFlushLine)( TidyDocImpl* doc, uint indent )
+void TY_(PFlushLine)( TidyDoc doc, uint indent )
 {
     TidyPrintImpl* pprint = &doc->pprint;
 
@@ -732,7 +732,7 @@ void TY_(PFlushLine)( TidyDocImpl* doc, uint indent )
     }
 }
 
-static void PCondFlushLine( TidyDocImpl* doc, uint indent )
+static void PCondFlushLine( TidyDoc doc, uint indent )
 {
     TidyPrintImpl* pprint = &doc->pprint;
 
@@ -760,7 +760,7 @@ static void PCondFlushLine( TidyDocImpl* doc, uint indent )
  * These need to be used in the right place. In same cases `PFlushLine`
  * and `PCondFlushLine` should still be used.
  */
-void TY_(PFlushLineSmart)( TidyDocImpl* doc, uint indent )
+void TY_(PFlushLineSmart)( TidyDoc doc, uint indent )
 {
     TidyPrintImpl* pprint = &doc->pprint;
 
@@ -782,7 +782,7 @@ void TY_(PFlushLineSmart)( TidyDocImpl* doc, uint indent )
     }
 }
 
-static void PCondFlushLineSmart( TidyDocImpl* doc, uint indent )
+static void PCondFlushLineSmart( TidyDoc doc, uint indent )
 {
     TidyPrintImpl* pprint = &doc->pprint;
 
@@ -812,7 +812,7 @@ static void PCondFlushLineSmart( TidyDocImpl* doc, uint indent )
     }
 }
 
-static void PPrintChar( TidyDocImpl* doc, uint c, uint mode )
+static void PPrintChar( TidyDoc doc, uint c, uint mode )
 {
     tmbchar entity[128];
     ctmbstr p;
@@ -1049,8 +1049,8 @@ static uint IncrWS( uint start, uint end, uint indent, int ixWS )
   to UTF-8 is deferred to the TY_(WriteChar)() routine called
   to flush the line buffer.
 */
-static void PPrintText( TidyDocImpl* doc, uint mode, uint indent,
-                        Node* node  )
+static void PPrintText( TidyDoc doc, uint mode, uint indent,
+                        TidyNode node  )
 {
     uint start = node->start;
     uint end = node->end;
@@ -1100,7 +1100,7 @@ static void PPrintText( TidyDocImpl* doc, uint mode, uint indent,
 }
 
 #if 0
-static void PPrintString( TidyDocImpl* doc, uint indent, ctmbstr str )
+static void PPrintString( TidyDoc doc, uint indent, ctmbstr str )
 {
     while ( *str != '\0' )
         AddChar( &doc->pprint, *str++ );
@@ -1108,7 +1108,7 @@ static void PPrintString( TidyDocImpl* doc, uint indent, ctmbstr str )
 #endif /* 0 */
 
 
-static void PPrintAttrValue( TidyDocImpl* doc, uint indent,
+static void PPrintAttrValue( TidyDoc doc, uint indent,
                              ctmbstr value, uint delim, Bool wrappable, Bool scriptAttr )
 {
     TidyPrintImpl* pprint = &doc->pprint;
@@ -1216,7 +1216,7 @@ static void PPrintAttrValue( TidyDocImpl* doc, uint indent,
     AddChar( pprint, delim );
 }
 
-static uint AttrIndent( TidyDocImpl* doc, Node* node, AttVal* ARG_UNUSED(attr) )
+static uint AttrIndent( TidyDoc doc, TidyNode node, TidyAttr ARG_UNUSED(attr) )
 {
   uint spaces = cfg( doc, TidyIndentSpaces );
   uint xtra = 2;  /* 1 for the '<', another for the ' ' */
@@ -1232,7 +1232,7 @@ static uint AttrIndent( TidyDocImpl* doc, Node* node, AttVal* ARG_UNUSED(attr) )
   return spaces;
 }
 
-static Bool AttrNoIndentFirst( /*TidyDocImpl* doc,*/ Node* node, AttVal* attr )
+static Bool AttrNoIndentFirst( /*TidyDoc doc,*/ TidyNode node, TidyAttr attr )
 {
   return ( attr==node->attributes );
   
@@ -1242,8 +1242,8 @@ static Bool AttrNoIndentFirst( /*TidyDocImpl* doc,*/ Node* node, AttVal* attr )
              */
 }
 
-static void PPrintAttribute( TidyDocImpl* doc, uint indent,
-                             Node *node, AttVal *attr )
+static void PPrintAttribute( TidyDoc doc, uint indent,
+                             TidyNode node, TidyAttr attr )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool xmlOut    = cfgBool( doc, TidyXmlOut );
@@ -1335,10 +1335,10 @@ static void PPrintAttribute( TidyDocImpl* doc, uint indent,
         PPrintAttrValue( doc, indent, attr->value, attr->delim, wrappable, no );
 }
 
-static void PPrintAttrs( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintAttrs( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
-    AttVal* av;
+    TidyAttr av;
 
     /* add xml:space attribute to pre and other elements */
     if ( cfgBool(doc, TidyXmlOut) && cfgBool(doc, TidyXmlSpace) &&
@@ -1367,7 +1367,7 @@ static void PPrintAttrs( TidyDocImpl* doc, uint indent, Node *node )
     }
 }
 
-Bool TY_(TextNodeEndWithSpace)( Lexer *lexer, Node *node )
+Bool TY_(TextNodeEndWithSpace)( Lexer *lexer, TidyNode node )
 {
     if (TY_(nodeIsText)(node) && node->end > node->start)
     {
@@ -1399,9 +1399,9 @@ Bool TY_(TextNodeEndWithSpace)( Lexer *lexer, Node *node )
  <p><img />
  x</p> won't.
 */
-static Bool AfterSpaceImp(Lexer *lexer, Node *node, Bool isEmpty)
+static Bool AfterSpaceImp(Lexer *lexer, TidyNode node, Bool isEmpty)
 {
-    Node *prev;
+    TidyNode prev;
 
     if ( !TY_(nodeCMIsInline)(node) )
         return yes;
@@ -1423,13 +1423,13 @@ static Bool AfterSpaceImp(Lexer *lexer, Node *node, Bool isEmpty)
     return AfterSpaceImp(lexer, node->parent, isEmpty);
 }
 
-static Bool AfterSpace(Lexer *lexer, Node *node)
+static Bool AfterSpace(Lexer *lexer, TidyNode node)
 {
     return AfterSpaceImp(lexer, node, TY_(nodeCMIsEmpty)(node));
 }
 
-static void PPrintEndTag( TidyDocImpl* doc, uint ARG_UNUSED(mode),
-                          uint ARG_UNUSED(indent), Node *node );
+static void PPrintEndTag( TidyDoc doc, uint ARG_UNUSED(mode),
+                          uint ARG_UNUSED(indent), TidyNode node );
 
 /*\
  *  See Issue #162 - void elements also get a closing tag, like img, br, ...
@@ -1446,7 +1446,7 @@ static void PPrintEndTag( TidyDocImpl* doc, uint ARG_UNUSED(mode),
  *  And maybe a switch(id) case would be faster.
 \*/
 
-static Bool TY_(isVoidElement)( Node *node )
+static Bool TY_(isVoidElement)( TidyNode node )
 {
     TidyTagId id;
     if ( !node )
@@ -1494,8 +1494,8 @@ static Bool TY_(isVoidElement)( Node *node )
     return no;
 }
 
-static void PPrintTag( TidyDocImpl* doc,
-                       uint mode, uint indent, Node *node )
+static void PPrintTag( TidyDoc doc,
+                       uint mode, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool uc = cfgBool( doc, TidyUpperCaseTags );
@@ -1577,8 +1577,8 @@ static void PPrintTag( TidyDocImpl* doc,
     }
 }
 
-static void PPrintEndTag( TidyDocImpl* doc, uint ARG_UNUSED(mode),
-                          uint ARG_UNUSED(indent), Node *node )
+static void PPrintEndTag( TidyDoc doc, uint ARG_UNUSED(mode),
+                          uint ARG_UNUSED(indent), TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool uc = cfgBool( doc, TidyUpperCaseTags );
@@ -1617,7 +1617,7 @@ static void PPrintEndTag( TidyDocImpl* doc, uint ARG_UNUSED(mode),
     AddChar( pprint, '>' );
 }
 
-static void PPrintComment( TidyDocImpl* doc, uint indent, Node* node )
+static void PPrintComment( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
 
@@ -1641,13 +1641,13 @@ static void PPrintComment( TidyDocImpl* doc, uint indent, Node* node )
         TY_(PFlushLineSmart)( doc, indent );
 }
 
-static void PPrintDocType( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintDocType( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     uint wraplen = cfg( doc, TidyWrapLen );
     uint spaces = cfg( doc, TidyIndentSpaces );
-    AttVal* fpi = TY_(GetAttrByName)(node, "PUBLIC");
-    AttVal* sys = TY_(GetAttrByName)(node, "SYSTEM");
+    TidyAttr fpi = TY_(GetAttrByName)(node, "PUBLIC");
+    TidyAttr sys = TY_(GetAttrByName)(node, "SYSTEM");
 
     /* todo: handle non-ASCII characters in FPI / SI / node->element */
 
@@ -1704,7 +1704,7 @@ static void PPrintDocType( TidyDocImpl* doc, uint indent, Node *node )
     PCondFlushLineSmart( doc, indent );
 }
 
-static void PPrintPI( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintPI( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     tchar c;
@@ -1735,9 +1735,9 @@ static void PPrintPI( TidyDocImpl* doc, uint indent, Node *node )
     PCondFlushLine( doc, indent );
 }
 
-static void PPrintXmlDecl( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintXmlDecl( TidyDoc doc, uint indent, TidyNode node )
 {
-    AttVal* att;
+    TidyAttr att;
     uint saveWrap;
     TidyPrintImpl* pprint = &doc->pprint;
     Bool ucAttrs;
@@ -1770,7 +1770,7 @@ static void PPrintXmlDecl( TidyDocImpl* doc, uint indent, Node *node )
 }
 
 /* note ASP and JSTE share <% ... %> syntax */
-static void PPrintAsp( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintAsp( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool wrapAsp  = cfgBool( doc, TidyWrapAsp );
@@ -1789,7 +1789,7 @@ static void PPrintAsp( TidyDocImpl* doc, uint indent, Node *node )
 }
 
 /* JSTE also supports <# ... #> syntax */
-static void PPrintJste( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintJste( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool wrapAsp = cfgBool( doc, TidyWrapAsp );
@@ -1805,7 +1805,7 @@ static void PPrintJste( TidyDocImpl* doc, uint indent, Node *node )
 }
 
 /* PHP is based on XML processing instructions */
-static void PPrintPhp( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintPhp( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool wrapPhp = cfgBool( doc, TidyWrapPhp );
@@ -1823,7 +1823,7 @@ static void PPrintPhp( TidyDocImpl* doc, uint indent, Node *node )
     WrapOn( doc, saveWrap );
 }
 
-static void PPrintCDATA( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintCDATA( TidyDoc doc, uint indent, TidyNode node )
 {
     uint saveWrap;
     TidyPrintImpl* pprint = &doc->pprint;
@@ -1842,7 +1842,7 @@ static void PPrintCDATA( TidyDocImpl* doc, uint indent, Node *node )
     WrapOn( doc, saveWrap );          /* restore wrapping */
 }
 
-static void PPrintSection( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintSection( TidyDoc doc, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
     Bool wrapSect = cfgBool( doc, TidyWrapSection );
@@ -1895,7 +1895,7 @@ static ctmbstr CSS_COMMENT_END       = "*/";
 static ctmbstr DEFAULT_COMMENT_START = "";
 static ctmbstr DEFAULT_COMMENT_END   = "";
 
-static Bool InsideHead( TidyDocImpl* doc, Node *node )
+static Bool InsideHead( TidyDoc doc, TidyNode node )
 {
   if ( nodeIsHEAD(node) )
     return yes;
@@ -1912,7 +1912,7 @@ static Bool InsideHead( TidyDocImpl* doc, Node *node )
    If it already ends on a newline, it is not
    necessary to print another before printing end tag.
 */
-static int TextEndsWithNewline(Lexer *lexer, Node *node, uint mode )
+static int TextEndsWithNewline(Lexer *lexer, TidyNode node, uint mode )
 {
     if ( (mode & (CDATA|COMMENT)) && TY_(nodeIsText)(node) && node->end > node->start )
     {
@@ -1940,7 +1940,7 @@ static int TextEndsWithNewline(Lexer *lexer, Node *node, uint mode )
  * Here the total white space is returned, and then a sister service, IncrWS() 
  * will advance the start of the lexer output by the amount of the indent.
 \*/
-static Bool TY_(nodeIsTextLike)( Node *node )
+static Bool TY_(nodeIsTextLike)( TidyNode node )
 {
     if ( TY_(nodeIsText)(node) )
         return yes;
@@ -1950,7 +1950,7 @@ static Bool TY_(nodeIsTextLike)( Node *node )
     return no;
 }
 
-static int TextStartsWithWhitespace( Lexer *lexer, Node *node, uint start, uint mode )
+static int TextStartsWithWhitespace( Lexer *lexer, TidyNode node, uint start, uint mode )
 {
     assert( node != NULL );
     if ( (mode & (CDATA|COMMENT)) && TY_(nodeIsTextLike)(node) && node->end > node->start && start >= node->start )
@@ -1967,7 +1967,7 @@ static int TextStartsWithWhitespace( Lexer *lexer, Node *node, uint start, uint 
     return -1;
 }
 
-static Bool HasCDATA( Lexer* lexer, Node* node )
+static Bool HasCDATA( Lexer* lexer, TidyNode node )
 {
     /* Scan forward through the textarray. Since the characters we're
     ** looking for are < 0x7f, we don't have to do any UTF-8 decoding.
@@ -1983,10 +1983,10 @@ static Bool HasCDATA( Lexer* lexer, Node* node )
 
 
 static
-void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *node )
+void PPrintScriptStyle( TidyDoc doc, uint mode, uint indent, TidyNode node )
 {
     TidyPrintImpl* pprint = &doc->pprint;
-    Node*   content;
+    TidyNode   content;
     ctmbstr commentStart = DEFAULT_COMMENT_START;
     ctmbstr commentEnd = DEFAULT_COMMENT_END;
     Bool    hasCData = no;
@@ -2004,7 +2004,7 @@ void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *node )
 
     if ( xhtmlOut && node->content != NULL )
     {
-        AttVal* type = attrGetTYPE(node);
+        TidyAttr type = attrGetTYPE(node);
 
         if (AttrValueIs(type, "text/javascript"))
         {
@@ -2090,7 +2090,7 @@ void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *node )
 
 
 
-static Bool ShouldIndent( TidyDocImpl* doc, Node *node )
+static Bool ShouldIndent( TidyDoc doc, TidyNode node )
 {
     TidyTriState indentContent = cfgAutoBool( doc, TidyIndentContent );
     if ( indentContent == TidyNoState )
@@ -2144,9 +2144,9 @@ static Bool ShouldIndent( TidyDocImpl* doc, Node *node )
 
  -- Sebastiano Vigna <vigna@dsi.unimi.it>
 */
-void TY_(PrintBody)( TidyDocImpl* doc )
+void TY_(PrintBody)( TidyDoc doc )
 {
-    Node *node = TY_(FindBody)( doc );
+    TidyNode node = TY_(FindBody)( doc );
 
     if ( node )
     {
@@ -2157,9 +2157,9 @@ void TY_(PrintBody)( TidyDocImpl* doc )
 
 /* #130 MathML attr and entity fix! 
    Support MathML namepsace */
-static void PPrintMathML( TidyDocImpl* doc, uint indent, Node *node )
+static void PPrintMathML( TidyDoc doc, uint indent, TidyNode node )
 {
-    Node *content;
+    TidyNode content;
     uint mode = OtherNamespace;
 
     PPrintTag( doc, mode, indent, node );
@@ -2170,9 +2170,9 @@ static void PPrintMathML( TidyDocImpl* doc, uint indent, Node *node )
     PPrintEndTag( doc, mode, indent, node );
 }
 
-void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
+void TY_(PPrintTree)( TidyDoc doc, uint mode, uint indent, TidyNode node )
 {
-    Node *content, *last;
+    TidyNode content, last;
     uint spaces = cfg( doc, TidyIndentSpaces );
     Bool xhtml = cfgBool( doc, TidyXhtmlOut );
 
@@ -2458,7 +2458,7 @@ void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
     }
 }
 
-void TY_(PPrintXMLTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
+void TY_(PPrintXMLTree)( TidyDoc doc, uint mode, uint indent, TidyNode node )
 {
     Bool xhtmlOut = cfgBool( doc, TidyXhtmlOut );
     if (node == NULL)
@@ -2481,7 +2481,7 @@ void TY_(PPrintXMLTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
     }
     else if ( node->type == RootNode )
     {
-        Node *content;
+        TidyNode content;
         for ( content = node->content;
               content != NULL;
               content = content->next )
@@ -2513,7 +2513,7 @@ void TY_(PPrintXMLTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
     else /* some kind of container element */
     {
         uint spaces = cfg( doc, TidyIndentSpaces );
-        Node *content;
+        TidyNode content;
         Bool mixed = no;
         uint cindent;
 

--- a/src/pprint.h
+++ b/src/pprint.h
@@ -62,13 +62,13 @@ typedef struct _TidyPrintImpl
 
 #if 0 && SUPPORT_ASIAN_ENCODINGS
 /* #431953 - start RJ Wraplen adjusted for smooth international ride */
-uint CWrapLen( TidyDocImpl* doc, uint ind );
+uint CWrapLen( TidyDoc doc, uint ind );
 #endif
 
-void TY_(InitPrintBuf)( TidyDocImpl* doc );
-void TY_(FreePrintBuf)( TidyDocImpl* doc );
+void TY_(InitPrintBuf)( TidyDoc doc );
+void TY_(FreePrintBuf)( TidyDoc doc );
 
-void TY_(PFlushLine)( TidyDocImpl* doc, uint indent );
+void TY_(PFlushLine)( TidyDoc doc, uint indent );
 
 
 /* print just the content of the body element.
@@ -78,12 +78,12 @@ void TY_(PFlushLine)( TidyDocImpl* doc, uint indent );
 ** -- Sebastiano Vigna <vigna@dsi.unimi.it>
 */
 
-void TY_(PrintBody)( TidyDocImpl* doc );       /* you can print an entire document */
+void TY_(PrintBody)( TidyDoc doc );       /* you can print an entire document */
                                           /* node as body using PPrintTree() */
 
-void TY_(PPrintTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node );
+void TY_(PPrintTree)( TidyDoc doc, uint mode, uint indent, TidyNode node );
 
-void TY_(PPrintXMLTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node );
+void TY_(PPrintXMLTree)( TidyDoc doc, uint mode, uint indent, TidyNode node );
 
 /*\
  * 20150515 - support using tabs instead of spaces

--- a/src/streamio.c
+++ b/src/streamio.c
@@ -89,7 +89,7 @@ StreamOut* TY_(StdOutOutput)(void)
 }
 #endif
 
-void  TY_(ReleaseStreamOut)( TidyDocImpl *doc,  StreamOut* out )
+void  TY_(ReleaseStreamOut)( TidyDoc doc,  StreamOut* out )
 {
     if ( out && out != &stderrStreamOut && out != &stdoutStreamOut )
     {
@@ -105,7 +105,7 @@ void  TY_(ReleaseStreamOut)( TidyDocImpl *doc,  StreamOut* out )
 
 static void InitLastPos( StreamIn *in );
 
-StreamIn* TY_(initStreamIn)( TidyDocImpl* doc, int encoding )
+StreamIn* TY_(initStreamIn)( TidyDoc doc, int encoding )
 {
     StreamIn *in = (StreamIn*) TidyDocAlloc( doc, sizeof(StreamIn) );
 
@@ -137,7 +137,7 @@ void TY_(freeStreamIn)(StreamIn* in)
     TidyFree(in->allocator, in);
 }
 
-StreamIn* TY_(FileInput)( TidyDocImpl* doc, FILE *fp, int encoding )
+StreamIn* TY_(FileInput)( TidyDoc doc, FILE *fp, int encoding )
 {
     StreamIn *in = TY_(initStreamIn)( doc, encoding );
     if ( TY_(initFileSource)( doc->allocator, &in->source, fp ) != 0 )
@@ -149,7 +149,7 @@ StreamIn* TY_(FileInput)( TidyDocImpl* doc, FILE *fp, int encoding )
     return in;
 }
 
-StreamIn* TY_(BufferInput)( TidyDocImpl* doc, TidyBuffer* buf, int encoding )
+StreamIn* TY_(BufferInput)( TidyDoc doc, TidyBuffer* buf, int encoding )
 {
     StreamIn *in = TY_(initStreamIn)( doc, encoding );
     tidyInitInputBuffer( &in->source, buf );
@@ -157,7 +157,7 @@ StreamIn* TY_(BufferInput)( TidyDocImpl* doc, TidyBuffer* buf, int encoding )
     return in;
 }
 
-StreamIn* TY_(UserInput)( TidyDocImpl* doc, TidyInputSource* source, int encoding )
+StreamIn* TY_(UserInput)( TidyDoc doc, TidyInputSource* source, int encoding )
 {
     StreamIn *in = TY_(initStreamIn)( doc, encoding );
     memcpy( &in->source, source, sizeof(TidyInputSource) );
@@ -553,7 +553,7 @@ void TY_(UngetChar)( uint c, StreamIn *in )
 ** Sink
 ************************/
 
-static StreamOut* initStreamOut( TidyDocImpl* doc, int encoding, uint nl )
+static StreamOut* initStreamOut( TidyDoc doc, int encoding, uint nl )
 {
     StreamOut* out = (StreamOut*) TidyDocAlloc( doc, sizeof(StreamOut) );
     TidyClearMemory( out, sizeof(StreamOut) );
@@ -563,21 +563,21 @@ static StreamOut* initStreamOut( TidyDocImpl* doc, int encoding, uint nl )
     return out;
 }
 
-StreamOut* TY_(FileOutput)( TidyDocImpl *doc, FILE* fp, int encoding, uint nl )
+StreamOut* TY_(FileOutput)( TidyDoc doc, FILE* fp, int encoding, uint nl )
 {
     StreamOut* out = initStreamOut( doc, encoding, nl );
     TY_(initFileSink)( &out->sink, fp );
     out->iotype = FileIO;
     return out;
 }
-StreamOut* TY_(BufferOutput)( TidyDocImpl *doc, TidyBuffer* buf, int encoding, uint nl )
+StreamOut* TY_(BufferOutput)( TidyDoc doc, TidyBuffer* buf, int encoding, uint nl )
 {
     StreamOut* out = initStreamOut( doc, encoding, nl );
     tidyInitOutputBuffer( &out->sink, buf );
     out->iotype = BufferIO;
     return out;
 }
-StreamOut* TY_(UserOutput)( TidyDocImpl *doc, TidyOutputSink* sink, int encoding, uint nl )
+StreamOut* TY_(UserOutput)( TidyDoc doc, TidyOutputSink* sink, int encoding, uint nl )
 {
     StreamOut* out = initStreamOut( doc, encoding, nl );
     memcpy( &out->sink, sink, sizeof(TidyOutputSink) );

--- a/src/streamio.h
+++ b/src/streamio.h
@@ -90,15 +90,15 @@ struct _StreamIn
 #endif
 
     /* Pointer back to document for error reporting */
-    TidyDocImpl* doc;
+    TidyDoc doc;
 };
 
-StreamIn* TY_(initStreamIn)( TidyDocImpl* doc, int encoding );
+StreamIn* TY_(initStreamIn)( TidyDoc doc, int encoding );
 void TY_(freeStreamIn)(StreamIn* in);
 
-StreamIn* TY_(FileInput)( TidyDocImpl* doc, FILE* fp, int encoding );
-StreamIn* TY_(BufferInput)( TidyDocImpl* doc, TidyBuffer* content, int encoding );
-StreamIn* TY_(UserInput)( TidyDocImpl* doc, TidyInputSource* source, int encoding );
+StreamIn* TY_(FileInput)( TidyDoc doc, FILE* fp, int encoding );
+StreamIn* TY_(BufferInput)( TidyDoc doc, TidyBuffer* content, int encoding );
+StreamIn* TY_(UserInput)( TidyDoc doc, TidyInputSource* source, int encoding );
 
 int       TY_(ReadBOMEncoding)(StreamIn *in);
 uint      TY_(ReadChar)( StreamIn* in );
@@ -124,13 +124,13 @@ struct _StreamOut
     TidyOutputSink sink;
 };
 
-StreamOut* TY_(FileOutput)( TidyDocImpl *doc, FILE* fp, int encoding, uint newln );
-StreamOut* TY_(BufferOutput)( TidyDocImpl *doc, TidyBuffer* buf, int encoding, uint newln );
-StreamOut* TY_(UserOutput)( TidyDocImpl *doc, TidyOutputSink* sink, int encoding, uint newln );
+StreamOut* TY_(FileOutput)( TidyDoc doc, FILE* fp, int encoding, uint newln );
+StreamOut* TY_(BufferOutput)( TidyDoc doc, TidyBuffer* buf, int encoding, uint newln );
+StreamOut* TY_(UserOutput)( TidyDoc doc, TidyOutputSink* sink, int encoding, uint newln );
 
 StreamOut* TY_(StdErrOutput)(void);
 /* StreamOut* StdOutOutput(void); */
-void       TY_(ReleaseStreamOut)( TidyDocImpl *doc, StreamOut* out );
+void       TY_(ReleaseStreamOut)( TidyDoc doc, StreamOut* out );
 
 void TY_(WriteChar)( uint c, StreamOut* out );
 void TY_(outBOM)( StreamOut *out );

--- a/src/tagask.c
+++ b/src/tagask.c
@@ -10,268 +10,268 @@
 #include "tidy.h"
 
 Bool TIDY_CALL tidyNodeIsText( TidyNode tnod )
-{ return TY_(nodeIsText)( tidyNodeToImpl(tnod) );
+{ return TY_(nodeIsText)( tnod );
 }
 Bool tidyNodeCMIsBlock( TidyNode tnod ); /* not exported yet */
 Bool tidyNodeCMIsBlock( TidyNode tnod )
-{ return TY_(nodeCMIsBlock)( tidyNodeToImpl(tnod) );
+{ return TY_(nodeCMIsBlock)( tnod );
 }
 Bool tidyNodeCMIsInline( TidyNode tnod ); /* not exported yet */
 Bool tidyNodeCMIsInline( TidyNode tnod )
-{ return TY_(nodeCMIsInline)( tidyNodeToImpl(tnod) );
+{ return TY_(nodeCMIsInline)( tnod );
 }
 Bool tidyNodeCMIsEmpty( TidyNode tnod ); /* not exported yet */
 Bool tidyNodeCMIsEmpty( TidyNode tnod )
-{ return TY_(nodeCMIsEmpty)( tidyNodeToImpl(tnod) );
+{ return TY_(nodeCMIsEmpty)( tnod );
 }
 Bool TIDY_CALL tidyNodeIsHeader( TidyNode tnod )
-{ return TY_(nodeIsHeader)( tidyNodeToImpl(tnod) );
+{ return TY_(nodeIsHeader)( tnod );
 }
 
 Bool TIDY_CALL tidyNodeIsHTML( TidyNode tnod )
-{ return nodeIsHTML( tidyNodeToImpl(tnod) );
+{ return nodeIsHTML( tnod );
 }
 Bool TIDY_CALL tidyNodeIsHEAD( TidyNode tnod )
-{ return nodeIsHEAD( tidyNodeToImpl(tnod) );
+{ return nodeIsHEAD( tnod );
 }
 Bool TIDY_CALL tidyNodeIsTITLE( TidyNode tnod )
-{ return nodeIsTITLE( tidyNodeToImpl(tnod) );
+{ return nodeIsTITLE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBASE( TidyNode tnod )
-{ return nodeIsBASE( tidyNodeToImpl(tnod) );
+{ return nodeIsBASE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsMETA( TidyNode tnod )
-{ return nodeIsMETA( tidyNodeToImpl(tnod) );
+{ return nodeIsMETA( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBODY( TidyNode tnod )
-{ return nodeIsBODY( tidyNodeToImpl(tnod) );
+{ return nodeIsBODY( tnod );
 }
 Bool TIDY_CALL tidyNodeIsFRAMESET( TidyNode tnod )
-{ return nodeIsFRAMESET( tidyNodeToImpl(tnod) );
+{ return nodeIsFRAMESET( tnod );
 }
 Bool TIDY_CALL tidyNodeIsFRAME( TidyNode tnod )
-{ return nodeIsFRAME( tidyNodeToImpl(tnod) );
+{ return nodeIsFRAME( tnod );
 }
 Bool TIDY_CALL tidyNodeIsIFRAME( TidyNode tnod )
-{ return nodeIsIFRAME( tidyNodeToImpl(tnod) );
+{ return nodeIsIFRAME( tnod );
 }
 Bool TIDY_CALL tidyNodeIsNOFRAMES( TidyNode tnod )
-{ return nodeIsNOFRAMES( tidyNodeToImpl(tnod) );
+{ return nodeIsNOFRAMES( tnod );
 }
 Bool TIDY_CALL tidyNodeIsHR( TidyNode tnod )
-{ return nodeIsHR( tidyNodeToImpl(tnod) );
+{ return nodeIsHR( tnod );
 }
 Bool TIDY_CALL tidyNodeIsH1( TidyNode tnod )
-{ return nodeIsH1( tidyNodeToImpl(tnod) );
+{ return nodeIsH1( tnod );
 }
 Bool TIDY_CALL tidyNodeIsH2( TidyNode tnod )
-{ return nodeIsH2( tidyNodeToImpl(tnod) );
+{ return nodeIsH2( tnod );
 }
 Bool TIDY_CALL tidyNodeIsPRE( TidyNode tnod )
-{ return nodeIsPRE( tidyNodeToImpl(tnod) );
+{ return nodeIsPRE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsLISTING( TidyNode tnod )
-{ return nodeIsLISTING( tidyNodeToImpl(tnod) );
+{ return nodeIsLISTING( tnod );
 }
 Bool TIDY_CALL tidyNodeIsP( TidyNode tnod )
-{ return nodeIsP( tidyNodeToImpl(tnod) );
+{ return nodeIsP( tnod );
 }
 Bool TIDY_CALL tidyNodeIsUL( TidyNode tnod )
-{ return nodeIsUL( tidyNodeToImpl(tnod) );
+{ return nodeIsUL( tnod );
 }
 Bool TIDY_CALL tidyNodeIsOL( TidyNode tnod )
-{ return nodeIsOL( tidyNodeToImpl(tnod) );
+{ return nodeIsOL( tnod );
 }
 Bool TIDY_CALL tidyNodeIsDL( TidyNode tnod )
-{ return nodeIsDL( tidyNodeToImpl(tnod) );
+{ return nodeIsDL( tnod );
 }
 Bool TIDY_CALL tidyNodeIsDIR( TidyNode tnod )
-{ return nodeIsDIR( tidyNodeToImpl(tnod) );
+{ return nodeIsDIR( tnod );
 }
 Bool TIDY_CALL tidyNodeIsLI( TidyNode tnod )
-{ return nodeIsLI( tidyNodeToImpl(tnod) );
+{ return nodeIsLI( tnod );
 }
 Bool TIDY_CALL tidyNodeIsDT( TidyNode tnod )
-{ return nodeIsDT( tidyNodeToImpl(tnod) );
+{ return nodeIsDT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsDD( TidyNode tnod )
-{ return nodeIsDD( tidyNodeToImpl(tnod) );
+{ return nodeIsDD( tnod );
 }
 Bool TIDY_CALL tidyNodeIsTABLE( TidyNode tnod )
-{ return nodeIsTABLE( tidyNodeToImpl(tnod) );
+{ return nodeIsTABLE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsCAPTION( TidyNode tnod )
-{ return nodeIsCAPTION( tidyNodeToImpl(tnod) );
+{ return nodeIsCAPTION( tnod );
 }
 Bool TIDY_CALL tidyNodeIsTD( TidyNode tnod )
-{ return nodeIsTD( tidyNodeToImpl(tnod) );
+{ return nodeIsTD( tnod );
 }
 Bool TIDY_CALL tidyNodeIsTH( TidyNode tnod )
-{ return nodeIsTH( tidyNodeToImpl(tnod) );
+{ return nodeIsTH( tnod );
 }
 Bool TIDY_CALL tidyNodeIsTR( TidyNode tnod )
-{ return nodeIsTR( tidyNodeToImpl(tnod) );
+{ return nodeIsTR( tnod );
 }
 Bool TIDY_CALL tidyNodeIsCOL( TidyNode tnod )
-{ return nodeIsCOL( tidyNodeToImpl(tnod) );
+{ return nodeIsCOL( tnod );
 }
 Bool TIDY_CALL tidyNodeIsCOLGROUP( TidyNode tnod )
-{ return nodeIsCOLGROUP( tidyNodeToImpl(tnod) );
+{ return nodeIsCOLGROUP( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBR( TidyNode tnod )
-{ return nodeIsBR( tidyNodeToImpl(tnod) );
+{ return nodeIsBR( tnod );
 }
 Bool TIDY_CALL tidyNodeIsA( TidyNode tnod )
-{ return nodeIsA( tidyNodeToImpl(tnod) );
+{ return nodeIsA( tnod );
 }
 Bool TIDY_CALL tidyNodeIsLINK( TidyNode tnod )
-{ return nodeIsLINK( tidyNodeToImpl(tnod) );
+{ return nodeIsLINK( tnod );
 }
 Bool TIDY_CALL tidyNodeIsB( TidyNode tnod )
-{ return nodeIsB( tidyNodeToImpl(tnod) );
+{ return nodeIsB( tnod );
 }
 Bool TIDY_CALL tidyNodeIsI( TidyNode tnod )
-{ return nodeIsI( tidyNodeToImpl(tnod) );
+{ return nodeIsI( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSTRONG( TidyNode tnod )
-{ return nodeIsSTRONG( tidyNodeToImpl(tnod) );
+{ return nodeIsSTRONG( tnod );
 }
 Bool TIDY_CALL tidyNodeIsEM( TidyNode tnod )
-{ return nodeIsEM( tidyNodeToImpl(tnod) );
+{ return nodeIsEM( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBIG( TidyNode tnod )
-{ return nodeIsBIG( tidyNodeToImpl(tnod) );
+{ return nodeIsBIG( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSMALL( TidyNode tnod )
-{ return nodeIsSMALL( tidyNodeToImpl(tnod) );
+{ return nodeIsSMALL( tnod );
 }
 Bool TIDY_CALL tidyNodeIsPARAM( TidyNode tnod )
-{ return nodeIsPARAM( tidyNodeToImpl(tnod) );
+{ return nodeIsPARAM( tnod );
 }
 Bool TIDY_CALL tidyNodeIsOPTION( TidyNode tnod )
-{ return nodeIsOPTION( tidyNodeToImpl(tnod) );
+{ return nodeIsOPTION( tnod );
 }
 Bool TIDY_CALL tidyNodeIsOPTGROUP( TidyNode tnod )
-{ return nodeIsOPTGROUP( tidyNodeToImpl(tnod) );
+{ return nodeIsOPTGROUP( tnod );
 }
 Bool TIDY_CALL tidyNodeIsIMG( TidyNode tnod )
-{ return nodeIsIMG( tidyNodeToImpl(tnod) );
+{ return nodeIsIMG( tnod );
 }
 Bool TIDY_CALL tidyNodeIsMAP( TidyNode tnod )
-{ return nodeIsMAP( tidyNodeToImpl(tnod) );
+{ return nodeIsMAP( tnod );
 }
 Bool TIDY_CALL tidyNodeIsAREA( TidyNode tnod )
-{ return nodeIsAREA( tidyNodeToImpl(tnod) );
+{ return nodeIsAREA( tnod );
 }
 Bool TIDY_CALL tidyNodeIsNOBR( TidyNode tnod )
-{ return nodeIsNOBR( tidyNodeToImpl(tnod) );
+{ return nodeIsNOBR( tnod );
 }
 Bool TIDY_CALL tidyNodeIsWBR( TidyNode tnod )
-{ return nodeIsWBR( tidyNodeToImpl(tnod) );
+{ return nodeIsWBR( tnod );
 }
 Bool TIDY_CALL tidyNodeIsFONT( TidyNode tnod )
-{ return nodeIsFONT( tidyNodeToImpl(tnod) );
+{ return nodeIsFONT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsLAYER( TidyNode tnod )
-{ return nodeIsLAYER( tidyNodeToImpl(tnod) );
+{ return nodeIsLAYER( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSPACER( TidyNode tnod )
-{ return nodeIsSPACER( tidyNodeToImpl(tnod) );
+{ return nodeIsSPACER( tnod );
 }
 Bool TIDY_CALL tidyNodeIsCENTER( TidyNode tnod )
-{ return nodeIsCENTER( tidyNodeToImpl(tnod) );
+{ return nodeIsCENTER( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSTYLE( TidyNode tnod )
-{ return nodeIsSTYLE( tidyNodeToImpl(tnod) );
+{ return nodeIsSTYLE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSCRIPT( TidyNode tnod )
-{ return nodeIsSCRIPT( tidyNodeToImpl(tnod) );
+{ return nodeIsSCRIPT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsNOSCRIPT( TidyNode tnod )
-{ return nodeIsNOSCRIPT( tidyNodeToImpl(tnod) );
+{ return nodeIsNOSCRIPT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsFORM( TidyNode tnod )
-{ return nodeIsFORM( tidyNodeToImpl(tnod) );
+{ return nodeIsFORM( tnod );
 }
 Bool TIDY_CALL tidyNodeIsTEXTAREA( TidyNode tnod )
-{ return nodeIsTEXTAREA( tidyNodeToImpl(tnod) );
+{ return nodeIsTEXTAREA( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBLOCKQUOTE( TidyNode tnod )
-{ return nodeIsBLOCKQUOTE( tidyNodeToImpl(tnod) );
+{ return nodeIsBLOCKQUOTE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsAPPLET( TidyNode tnod )
-{ return nodeIsAPPLET( tidyNodeToImpl(tnod) );
+{ return nodeIsAPPLET( tnod );
 }
 Bool TIDY_CALL tidyNodeIsOBJECT( TidyNode tnod )
-{ return nodeIsOBJECT( tidyNodeToImpl(tnod) );
+{ return nodeIsOBJECT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsDIV( TidyNode tnod )
-{ return nodeIsDIV( tidyNodeToImpl(tnod) );
+{ return nodeIsDIV( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSPAN( TidyNode tnod )
-{ return nodeIsSPAN( tidyNodeToImpl(tnod) );
+{ return nodeIsSPAN( tnod );
 }
 Bool TIDY_CALL tidyNodeIsINPUT( TidyNode tnod )
-{ return nodeIsINPUT( tidyNodeToImpl(tnod) );
+{ return nodeIsINPUT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsQ( TidyNode tnod )
-{ return nodeIsQ( tidyNodeToImpl(tnod) );
+{ return nodeIsQ( tnod );
 }
 Bool TIDY_CALL tidyNodeIsLABEL( TidyNode tnod )
-{ return nodeIsLABEL( tidyNodeToImpl(tnod) );
+{ return nodeIsLABEL( tnod );
 }
 Bool TIDY_CALL tidyNodeIsH3( TidyNode tnod )
-{ return nodeIsH3( tidyNodeToImpl(tnod) );
+{ return nodeIsH3( tnod );
 }
 Bool TIDY_CALL tidyNodeIsH4( TidyNode tnod )
-{ return nodeIsH4( tidyNodeToImpl(tnod) );
+{ return nodeIsH4( tnod );
 }
 Bool TIDY_CALL tidyNodeIsH5( TidyNode tnod )
-{ return nodeIsH5( tidyNodeToImpl(tnod) );
+{ return nodeIsH5( tnod );
 }
 Bool TIDY_CALL tidyNodeIsH6( TidyNode tnod )
-{ return nodeIsH6( tidyNodeToImpl(tnod) );
+{ return nodeIsH6( tnod );
 }
 Bool TIDY_CALL tidyNodeIsADDRESS( TidyNode tnod )
-{ return nodeIsADDRESS( tidyNodeToImpl(tnod) );
+{ return nodeIsADDRESS( tnod );
 }
 Bool TIDY_CALL tidyNodeIsXMP( TidyNode tnod )
-{ return nodeIsXMP( tidyNodeToImpl(tnod) );
+{ return nodeIsXMP( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSELECT( TidyNode tnod )
-{ return nodeIsSELECT( tidyNodeToImpl(tnod) );
+{ return nodeIsSELECT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBLINK( TidyNode tnod )
-{ return nodeIsBLINK( tidyNodeToImpl(tnod) );
+{ return nodeIsBLINK( tnod );
 }
 Bool TIDY_CALL tidyNodeIsMARQUEE( TidyNode tnod )
-{ return nodeIsMARQUEE( tidyNodeToImpl(tnod) );
+{ return nodeIsMARQUEE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsEMBED( TidyNode tnod )
-{ return nodeIsEMBED( tidyNodeToImpl(tnod) );
+{ return nodeIsEMBED( tnod );
 }
 Bool TIDY_CALL tidyNodeIsBASEFONT( TidyNode tnod )
-{ return nodeIsBASEFONT( tidyNodeToImpl(tnod) );
+{ return nodeIsBASEFONT( tnod );
 }
 Bool TIDY_CALL tidyNodeIsISINDEX( TidyNode tnod )
-{ return nodeIsISINDEX( tidyNodeToImpl(tnod) );
+{ return nodeIsISINDEX( tnod );
 }
 Bool TIDY_CALL tidyNodeIsS( TidyNode tnod )
-{ return nodeIsS( tidyNodeToImpl(tnod) );
+{ return nodeIsS( tnod );
 }
 Bool TIDY_CALL tidyNodeIsSTRIKE( TidyNode tnod )
-{ return nodeIsSTRIKE( tidyNodeToImpl(tnod) );
+{ return nodeIsSTRIKE( tnod );
 }
 Bool TIDY_CALL tidyNodeIsU( TidyNode tnod )
-{ return nodeIsU( tidyNodeToImpl(tnod) );
+{ return nodeIsU( tnod );
 }
 Bool TIDY_CALL tidyNodeIsMENU( TidyNode tnod )
-{ return nodeIsMENU( tidyNodeToImpl(tnod) );
+{ return nodeIsMENU( tnod );
 }
 
 /* HTML5 */
 Bool TIDY_CALL tidyNodeIsDATALIST( TidyNode tnod )
-{ return nodeIsDATALIST( tidyNodeToImpl(tnod) );
+{ return nodeIsDATALIST( tnod );
 }
 
 

--- a/src/tags.c
+++ b/src/tags.c
@@ -343,7 +343,7 @@ static uint tagsHash(ctmbstr s)
     return hashval % ELEMENT_HASH_SIZE;
 }
 
-static const Dict *tagsInstall(TidyDocImpl* doc, TidyTagImpl* tags, const Dict* old)
+static const Dict *tagsInstall(TidyDoc doc, TidyTagImpl* tags, const Dict* old)
 {
     DictHash *np;
     uint hashval;
@@ -361,7 +361,7 @@ static const Dict *tagsInstall(TidyDocImpl* doc, TidyTagImpl* tags, const Dict* 
     return old;
 }
 
-static void tagsRemoveFromHash( TidyDocImpl* doc, TidyTagImpl* tags, ctmbstr s )
+static void tagsRemoveFromHash( TidyDoc doc, TidyTagImpl* tags, ctmbstr s )
 {
     uint h = tagsHash(s);
     DictHash *p, *prev = NULL;
@@ -381,7 +381,7 @@ static void tagsRemoveFromHash( TidyDocImpl* doc, TidyTagImpl* tags, ctmbstr s )
     }
 }
 
-static void tagsEmptyHash( TidyDocImpl* doc, TidyTagImpl* tags )
+static void tagsEmptyHash( TidyDoc doc, TidyTagImpl* tags )
 {
     uint i;
     DictHash *prev, *next;
@@ -403,7 +403,7 @@ static void tagsEmptyHash( TidyDocImpl* doc, TidyTagImpl* tags )
 }
 #endif /* ELEMENT_HASH_LOOKUP */
 
-static const Dict* tagsLookup( TidyDocImpl* doc, TidyTagImpl* tags, ctmbstr s )
+static const Dict* tagsLookup( TidyDoc doc, TidyTagImpl* tags, ctmbstr s )
 {
     const Dict *np;
 #if ELEMENT_HASH_LOOKUP
@@ -445,7 +445,7 @@ static const Dict* tagsLookup( TidyDocImpl* doc, TidyTagImpl* tags, ctmbstr s )
     return NULL;
 }
 
-static Dict* NewDict( TidyDocImpl* doc, ctmbstr name )
+static Dict* NewDict( TidyDoc doc, ctmbstr name )
 {
     Dict *np = (Dict*) TidyDocAlloc( doc, sizeof(Dict) );
     np->id = TidyTag_UNKNOWN;
@@ -459,14 +459,14 @@ static Dict* NewDict( TidyDocImpl* doc, ctmbstr name )
     return np;
 }
 
-static void FreeDict( TidyDocImpl* doc, Dict *d )
+static void FreeDict( TidyDoc doc, Dict *d )
 {
     if ( d )
         TidyDocFree( doc, d->name );
     TidyDocFree( doc, d );
 }
 
-static void declare( TidyDocImpl* doc, TidyTagImpl* tags,
+static void declare( TidyDoc doc, TidyTagImpl* tags,
                      ctmbstr name, uint versions, uint model,
                      Parser *parser, CheckAttribs *chkattrs )
 {
@@ -544,7 +544,7 @@ void show_have_html5(void)
 #endif
 
 /* public interface for finding tag by name */
-Bool TY_(FindTag)( TidyDocImpl* doc, Node *node )
+Bool TY_(FindTag)( TidyDoc doc, TidyNode node )
 {
     const Dict *np = NULL;
     if ( cfgBool(doc, TidyXmlTags) )
@@ -573,7 +573,7 @@ const Dict* TY_(LookupTagDef)( TidyTagId tid )
     return NULL;
 }
 
-Parser* TY_(FindParser)( TidyDocImpl* doc, Node *node )
+Parser* TY_(FindParser)( TidyDoc doc, TidyNode node )
 {
     const Dict* np = tagsLookup( doc, &doc->tags, node->element );
     if ( np )
@@ -581,7 +581,7 @@ Parser* TY_(FindParser)( TidyDocImpl* doc, Node *node )
     return NULL;
 }
 
-void TY_(DefineTag)( TidyDocImpl* doc, UserTagType tagType, ctmbstr name )
+void TY_(DefineTag)( TidyDoc doc, UserTagType tagType, ctmbstr name )
 {
     Parser* parser = 0;
     uint cm = CM_UNKNOWN;
@@ -616,12 +616,12 @@ void TY_(DefineTag)( TidyDocImpl* doc, UserTagType tagType, ctmbstr name )
         declare( doc, &doc->tags, name, vers, cm, parser, 0 );
 }
 
-TidyIterator   TY_(GetDeclaredTagList)( TidyDocImpl* doc )
+TidyIterator   TY_(GetDeclaredTagList)( TidyDoc doc )
 {
     return (TidyIterator) doc->tags.declared_tag_list;
 }
 
-ctmbstr        TY_(GetNextDeclaredTag)( TidyDocImpl* ARG_UNUSED(doc),
+ctmbstr        TY_(GetNextDeclaredTag)( TidyDoc ARG_UNUSED(doc),
                                         UserTagType tagType, TidyIterator* iter )
 {
     ctmbstr name = NULL;
@@ -660,7 +660,7 @@ ctmbstr        TY_(GetNextDeclaredTag)( TidyDocImpl* ARG_UNUSED(doc),
     return name;
 }
 
-void TY_(InitTags)( TidyDocImpl* doc )
+void TY_(InitTags)( TidyDoc doc )
 {
     Dict* xml;
     TidyTagImpl* tags = &doc->tags;
@@ -680,7 +680,7 @@ void TY_(InitTags)( TidyDocImpl* doc )
 /* By default, zap all of them.  But allow
 ** an single type to be specified.
 */
-void TY_(FreeDeclaredTags)( TidyDocImpl* doc, UserTagType tagType )
+void TY_(FreeDeclaredTags)( TidyDoc doc, UserTagType tagType )
 {
     TidyTagImpl* tags = &doc->tags;
     Dict *curr, *next = NULL, *prev = NULL;
@@ -738,7 +738,7 @@ void TY_(FreeDeclaredTags)( TidyDocImpl* doc, UserTagType tagType )
  * NOTE: For each change added to here, there must 
  * be a RESET added in TY_(ResetTags) below!
 \*/
-void TY_(AdjustTags)( TidyDocImpl *doc )
+void TY_(AdjustTags)( TidyDoc doc )
 {
     Dict *np = (Dict *)TY_(LookupTagDef)( TidyTag_A );
     TidyTagImpl* tags = &doc->tags;
@@ -780,7 +780,7 @@ void TY_(AdjustTags)( TidyDocImpl *doc )
     }
 }
 
-Bool TY_(IsHTML5Mode)( TidyDocImpl *doc )
+Bool TY_(IsHTML5Mode)( TidyDoc doc )
 {
     return doc->HTML5Mode;
 }
@@ -792,7 +792,7 @@ Bool TY_(IsHTML5Mode)( TidyDocImpl *doc )
  * For every change made in the above AdjustTags,
  * the equivalent reset must be added here.
 \*/
-void TY_(ResetTags)( TidyDocImpl *doc )
+void TY_(ResetTags)( TidyDoc doc )
 {
     Dict *np = (Dict *)TY_(LookupTagDef)( TidyTag_A );
     TidyTagImpl* tags = &doc->tags;
@@ -818,7 +818,7 @@ void TY_(ResetTags)( TidyDocImpl *doc )
     doc->HTML5Mode = yes;   /* set HTML5 mode */
 }
 
-void TY_(FreeTags)( TidyDocImpl* doc )
+void TY_(FreeTags)( TidyDoc doc )
 {
     TidyTagImpl* tags = &doc->tags;
 
@@ -836,9 +836,9 @@ void TY_(FreeTags)( TidyDocImpl* doc )
 
 
 /* default method for checking an element's attributes */
-void TY_(CheckAttributes)( TidyDocImpl* doc, Node *node )
+void TY_(CheckAttributes)( TidyDoc doc, TidyNode node )
 {
-    AttVal *next, *attval = node->attributes;
+    TidyAttr next, attval = node->attributes;
     while (attval)
     {
         next = attval->next;
@@ -849,7 +849,7 @@ void TY_(CheckAttributes)( TidyDocImpl* doc, Node *node )
 
 /* methods for checking attributes for specific elements */
 
-void CheckIMG( TidyDocImpl* doc, Node *node )
+void CheckIMG( TidyDoc doc, TidyNode node )
 {
     Bool HasAlt = TY_(AttrGetById)(node, TidyAttr_ALT) != NULL;
     Bool HasSrc = TY_(AttrGetById)(node, TidyAttr_SRC) != NULL;
@@ -869,7 +869,7 @@ void CheckIMG( TidyDocImpl* doc, Node *node )
         }
 
         if ( alttext ) {
-            AttVal *attval = TY_(AddAttribute)( doc, node, "alt", alttext );
+            TidyAttr attval = TY_(AddAttribute)( doc, node, "alt", alttext );
             TY_(ReportAttrError)( doc, node, attval, INSERTING_AUTO_ATTRIBUTE);
         }
     }
@@ -884,9 +884,9 @@ void CheckIMG( TidyDocImpl* doc, Node *node )
     }
 }
 
-void CheckCaption(TidyDocImpl* doc, Node *node)
+void CheckCaption(TidyDoc doc, TidyNode node)
 {
-    AttVal *attval;
+    TidyAttr attval;
 
     TY_(CheckAttributes)(doc, node);
 
@@ -903,12 +903,12 @@ void CheckCaption(TidyDocImpl* doc, Node *node)
         TY_(ReportAttrError)(doc, node, attval, BAD_ATTRIBUTE_VALUE);
 }
 
-void CheckHTML( TidyDocImpl* doc, Node *node )
+void CheckHTML( TidyDoc doc, TidyNode node )
 {
     TY_(CheckAttributes)(doc, node);
 }
 
-void CheckAREA( TidyDocImpl* doc, Node *node )
+void CheckAREA( TidyDoc doc, TidyNode node )
 {
     Bool HasAlt = TY_(AttrGetById)(node, TidyAttr_ALT) != NULL;
     Bool HasHref = TY_(AttrGetById)(node, TidyAttr_HREF) != NULL;
@@ -929,9 +929,9 @@ void CheckAREA( TidyDocImpl* doc, Node *node )
         TY_(ReportMissingAttr)( doc, node, "href" );
 }
 
-void CheckTABLE( TidyDocImpl* doc, Node *node )
+void CheckTABLE( TidyDoc doc, TidyNode node )
 {
-    AttVal* attval;
+    TidyAttr attval;
     Bool HasSummary = (TY_(AttrGetById)(node, TidyAttr_SUMMARY) != NULL) ? yes : no;
     uint vers = TY_(HTMLVersion)(doc);  /* Issue #377 - Also applies to XHTML5 */
     Bool isHTML5 = ((vers == HT50)||(vers == XH50)) ? yes : no;
@@ -965,7 +965,7 @@ void CheckTABLE( TidyDocImpl* doc, Node *node )
 }
 
 /* report missing href attribute; report missing rel attribute */
-void CheckLINK( TidyDocImpl* doc, Node *node )
+void CheckLINK( TidyDoc doc, TidyNode node )
 {
     Bool HasHref = TY_(AttrGetById)(node, TidyAttr_HREF) != NULL;
     Bool HasRel = TY_(AttrGetById)(node, TidyAttr_REL) != NULL;
@@ -982,12 +982,12 @@ void CheckLINK( TidyDocImpl* doc, Node *node )
     }
 }
 
-Bool TY_(nodeIsText)( Node* node )
+Bool TY_(nodeIsText)( TidyNode node )
 {
   return ( node && node->type == TextNode );
 }
 
-Bool TY_(nodeHasText)( TidyDocImpl* doc, Node* node )
+Bool TY_(nodeHasText)( TidyDoc doc, TidyNode node )
 {
   if ( doc && node )
   {
@@ -1003,7 +1003,7 @@ Bool TY_(nodeHasText)( TidyDocImpl* doc, Node* node )
   return no;
 }
 
-Bool TY_(nodeIsElement)( Node* node )
+Bool TY_(nodeIsElement)( TidyNode node )
 {
   return ( node &&
            (node->type == StartTag || node->type == StartEndTag) );
@@ -1013,7 +1013,7 @@ Bool TY_(nodeIsElement)( Node* node )
 /* Compare & result to operand.  If equal, then all bits
 ** requested are set.
 */
-Bool nodeMatchCM( Node* node, uint contentModel )
+Bool nodeMatchCM( TidyNode node, uint contentModel )
 {
   return ( node && node->tag &&
            (node->tag->model & contentModel) == contentModel );
@@ -1022,26 +1022,26 @@ Bool nodeMatchCM( Node* node, uint contentModel )
 
 /* True if any of the bits requested are set.
 */
-Bool TY_(nodeHasCM)( Node* node, uint contentModel )
+Bool TY_(nodeHasCM)( TidyNode node, uint contentModel )
 {
   return ( node && node->tag &&
            (node->tag->model & contentModel) != 0 );
 }
 
-Bool TY_(nodeCMIsBlock)( Node* node )
+Bool TY_(nodeCMIsBlock)( TidyNode node )
 {
   return TY_(nodeHasCM)( node, CM_BLOCK );
 }
-Bool TY_(nodeCMIsInline)( Node* node )
+Bool TY_(nodeCMIsInline)( TidyNode node )
 {
   return TY_(nodeHasCM)( node, CM_INLINE );
 }
-Bool TY_(nodeCMIsEmpty)( Node* node )
+Bool TY_(nodeCMIsEmpty)( TidyNode node )
 {
   return TY_(nodeHasCM)( node, CM_EMPTY );
 }
 
-Bool TY_(nodeIsHeader)( Node* node )
+Bool TY_(nodeIsHeader)( TidyNode node )
 {
     TidyTagId tid = TagId( node  );
     return ( tid && (
@@ -1053,7 +1053,7 @@ Bool TY_(nodeIsHeader)( Node* node )
              tid == TidyTag_H6 ));
 }
 
-uint TY_(nodeHeaderLevel)( Node* node )
+uint TY_(nodeHeaderLevel)( TidyNode node )
 {
     TidyTagId tid = TagId( node  );
     switch ( tid )
@@ -1079,7 +1079,7 @@ uint TY_(nodeHeaderLevel)( Node* node )
 }
 
 /* [i_a] generic node tree traversal; see also <tidy-int.h> */
-NodeTraversalSignal TY_(TraverseNodeTree)(TidyDocImpl* doc, Node* node, NodeTraversalCallBack *cb, void *propagate )
+NodeTraversalSignal TY_(TraverseNodeTree)(TidyDoc doc, TidyNode node, NodeTraversalCallBack *cb, void *propagate )
 {
     while (node)
     {

--- a/src/tags.h
+++ b/src/tags.h
@@ -14,8 +14,8 @@
 #include "forward.h"
 #include "attrdict.h"
 
-typedef void (Parser)( TidyDocImpl* doc, Node *node, GetTokenMode mode );
-typedef void (CheckAttribs)( TidyDocImpl* doc, Node *node );
+typedef void (Parser)( TidyDoc doc, TidyNode node, GetTokenMode mode );
+typedef void (CheckAttribs)( TidyDoc doc, TidyNode node );
 
 /*
  Tag dictionary node
@@ -75,20 +75,20 @@ typedef struct _TidyTagImpl TidyTagImpl;
 
 /* interface for finding tag by name */
 const Dict* TY_(LookupTagDef)( TidyTagId tid );
-Bool    TY_(FindTag)( TidyDocImpl* doc, Node *node );
-Parser* TY_(FindParser)( TidyDocImpl* doc, Node *node );
-void    TY_(DefineTag)( TidyDocImpl* doc, UserTagType tagType, ctmbstr name );
-void    TY_(FreeDeclaredTags)( TidyDocImpl* doc, UserTagType tagType ); /* tagtype_null to free all */
+Bool    TY_(FindTag)( TidyDoc doc, TidyNode node );
+Parser* TY_(FindParser)( TidyDoc doc, TidyNode node );
+void    TY_(DefineTag)( TidyDoc doc, UserTagType tagType, ctmbstr name );
+void    TY_(FreeDeclaredTags)( TidyDoc doc, UserTagType tagType ); /* tagtype_null to free all */
 
-TidyIterator   TY_(GetDeclaredTagList)( TidyDocImpl* doc );
-ctmbstr        TY_(GetNextDeclaredTag)( TidyDocImpl* doc, UserTagType tagType,
+TidyIterator   TY_(GetDeclaredTagList)( TidyDoc doc );
+ctmbstr        TY_(GetNextDeclaredTag)( TidyDoc doc, UserTagType tagType,
                                         TidyIterator* iter );
 
-void TY_(InitTags)( TidyDocImpl* doc );
-void TY_(FreeTags)( TidyDocImpl* doc );
-void TY_(AdjustTags)( TidyDocImpl *doc ); /* if NOT HTML5 DOCTYPE, fall back to HTML4 legacy mode */
-void TY_(ResetTags)( TidyDocImpl *doc ); /* set table to HTML5 mode */
-Bool TY_(IsHTML5Mode)( TidyDocImpl *doc );
+void TY_(InitTags)( TidyDoc doc );
+void TY_(FreeTags)( TidyDoc doc );
+void TY_(AdjustTags)( TidyDoc doc ); /* if NOT HTML5 DOCTYPE, fall back to HTML4 legacy mode */
+void TY_(ResetTags)( TidyDoc doc ); /* set table to HTML5 mode */
+Bool TY_(IsHTML5Mode)( TidyDoc doc );
 
 /* Parser methods for tags */
 
@@ -121,29 +121,29 @@ CheckAttribs TY_(CheckAttributes);
 #define TagId(node)        ((node) && (node)->tag ? (node)->tag->id : TidyTag_UNKNOWN)
 #define TagIsId(node, tid) ((node) && (node)->tag && (node)->tag->id == tid)
 
-Bool TY_(nodeIsText)( Node* node );
-Bool TY_(nodeIsElement)( Node* node );
+Bool TY_(nodeIsText)( TidyNode node );
+Bool TY_(nodeIsElement)( TidyNode node );
 
-Bool TY_(nodeHasText)( TidyDocImpl* doc, Node* node );
+Bool TY_(nodeHasText)( TidyDoc doc, TidyNode node );
 
 #if 0
 /* Compare & result to operand.  If equal, then all bits
 ** requested are set.
 */
-Bool nodeMatchCM( Node* node, uint contentModel );
+Bool nodeMatchCM( TidyNode node, uint contentModel );
 #endif
 
 /* True if any of the bits requested are set.
 */
-Bool TY_(nodeHasCM)( Node* node, uint contentModel );
+Bool TY_(nodeHasCM)( TidyNode node, uint contentModel );
 
-Bool TY_(nodeCMIsBlock)( Node* node );
-Bool TY_(nodeCMIsInline)( Node* node );
-Bool TY_(nodeCMIsEmpty)( Node* node );
+Bool TY_(nodeCMIsBlock)( TidyNode node );
+Bool TY_(nodeCMIsInline)( TidyNode node );
+Bool TY_(nodeCMIsEmpty)( TidyNode node );
 
 
-Bool TY_(nodeIsHeader)( Node* node );     /* H1, H2, ..., H6 */
-uint TY_(nodeHeaderLevel)( Node* node );  /* 1, 2, ..., 6 */
+Bool TY_(nodeIsHeader)( TidyNode node );     /* H1, H2, ..., H6 */
+uint TY_(nodeHeaderLevel)( TidyNode node );  /* 1, 2, ..., 6 */
 
 #define nodeIsHTML( node )       TagIsId( node, TidyTag_HTML )
 #define nodeIsHEAD( node )       TagIsId( node, TidyTag_HEAD )

--- a/src/tidy-int.h
+++ b/src/tidy-int.h
@@ -97,20 +97,6 @@ struct _TidyDoc
 };
 
 
-/* Twizzle internal/external types */
-
-#define tidyDocToImpl( tdoc )       (tdoc)
-#define tidyImplToDoc( doc )        (doc)
-
-#define tidyNodeToImpl( tnod )      (tnod)
-#define tidyImplToNode( node )      (node)
-
-#define tidyAttrToImpl( tattr )     (tattr)
-#define tidyImplToAttr( attval )    (attval)
-
-#define tidyOptionToImpl( topt )    (topt)
-#define tidyImplToOption( option )  (option)
-
 /** Wrappers for easy memory allocation using the document's allocator */
 #define TidyDocAlloc(doc, size) TidyAlloc((doc)->allocator, size)
 #define TidyDocRealloc(doc, block, size) TidyRealloc((doc)->allocator, block, size)

--- a/src/tidy-int.h
+++ b/src/tidy-int.h
@@ -32,10 +32,10 @@
 #define flg_BadForm     0x00000001
 #define flg_BadMain     0x00000002
 
-struct _TidyDocImpl
+struct _TidyDoc
 {
     /* The Document Tree (and backing store buffer) */
-    Node                root;       /* This MUST remain the first declared 
+    struct _TidyNode    root;       /* This MUST remain the first declared 
                                        variable in this structure */
     Lexer*              lexer;
 
@@ -98,33 +98,18 @@ struct _TidyDocImpl
 
 
 /* Twizzle internal/external types */
-#ifdef NEVER
-TidyDocImpl* tidyDocToImpl( TidyDoc tdoc );
-TidyDoc      tidyImplToDoc( TidyDocImpl* impl );
 
-Node*        tidyNodeToImpl( TidyNode tnod );
-TidyNode     tidyImplToNode( Node* node );
+#define tidyDocToImpl( tdoc )       (tdoc)
+#define tidyImplToDoc( doc )        (doc)
 
-AttVal*      tidyAttrToImpl( TidyAttr tattr );
-TidyAttr     tidyImplToAttr( AttVal* attval );
+#define tidyNodeToImpl( tnod )      (tnod)
+#define tidyImplToNode( node )      (node)
 
-const TidyOptionImpl* tidyOptionToImpl( TidyOption topt );
-TidyOption   tidyImplToOption( const TidyOptionImpl* option );
-#else
+#define tidyAttrToImpl( tattr )     (tattr)
+#define tidyImplToAttr( attval )    (attval)
 
-#define tidyDocToImpl( tdoc )       ((TidyDocImpl*)(tdoc))
-#define tidyImplToDoc( doc )        ((TidyDoc)(doc))
-
-#define tidyNodeToImpl( tnod )      ((Node*)(tnod))
-#define tidyImplToNode( node )      ((TidyNode)(node))
-
-#define tidyAttrToImpl( tattr )     ((AttVal*)(tattr))
-#define tidyImplToAttr( attval )    ((TidyAttr)(attval))
-
-#define tidyOptionToImpl( topt )    ((const TidyOptionImpl*)(topt))
-#define tidyImplToOption( option )  ((TidyOption)(option))
-
-#endif
+#define tidyOptionToImpl( topt )    (topt)
+#define tidyImplToOption( option )  (option)
 
 /** Wrappers for easy memory allocation using the document's allocator */
 #define TidyDocAlloc(doc, size) TidyAlloc((doc)->allocator, size)
@@ -132,7 +117,7 @@ TidyOption   tidyImplToOption( const TidyOptionImpl* option );
 #define TidyDocFree(doc, block) TidyFree((doc)->allocator, block)
 #define TidyDocPanic(doc, msg) TidyPanic((doc)->allocator, msg)
 
-int          TY_(DocParseStream)( TidyDocImpl* impl, StreamIn* in );
+int          TY_(DocParseStream)( TidyDoc impl, StreamIn* in );
 
 /*
    [i_a] generic node tree traversal code; used in several spots.
@@ -152,8 +137,8 @@ typedef enum
     ExitTraversal            /* terminate traversal on the spot */
 } NodeTraversalSignal;
 
-typedef NodeTraversalSignal NodeTraversalCallBack(TidyDocImpl* doc, Node* node, void *propagate);
+typedef NodeTraversalSignal NodeTraversalCallBack(TidyDoc doc, TidyNode node, void *propagate);
 
-NodeTraversalSignal TY_(TraverseNodeTree)(TidyDocImpl* doc, Node* node, NodeTraversalCallBack *cb, void *propagate);
+NodeTraversalSignal TY_(TraverseNodeTree)(TidyDoc doc, TidyNode node, NodeTraversalCallBack *cb, void *propagate);
 
 #endif /* __TIDY_INT_H__ */

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -83,20 +83,17 @@ static int          tidyDocSaveStream( TidyDoc impl, StreamOut* out );
 
 TidyDoc TIDY_CALL       tidyCreate(void)
 {
-  TidyDoc impl = tidyDocCreate( &TY_(g_default_allocator) );
-  return tidyImplToDoc( impl );
+  return tidyDocCreate( &TY_(g_default_allocator) );
 }
 
 TidyDoc TIDY_CALL tidyCreateWithAllocator( TidyAllocator *allocator )
 {
-  TidyDoc impl = tidyDocCreate( allocator );
-  return tidyImplToDoc( impl );
+  return tidyDocCreate( allocator );
 }
 
 void TIDY_CALL          tidyRelease( TidyDoc tdoc )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  tidyDocRelease( impl );
+  tidyDocRelease( tdoc );
 }
 
 TidyDoc tidyDocCreate( TidyAllocator *allocator )
@@ -156,15 +153,13 @@ void          tidyDocRelease( TidyDoc doc )
 */
 void TIDY_CALL        tidySetAppData( TidyDoc tdoc, void* appData )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
-    impl->appData = appData;
+  if ( tdoc )
+    tdoc->appData = appData;
 }
 void* TIDY_CALL       tidyGetAppData( TidyDoc tdoc )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
-    return impl->appData;
+  if ( tdoc )
+    return tdoc->appData;
   return NULL;
 }
 
@@ -178,10 +173,9 @@ ctmbstr TIDY_CALL     tidyReleaseDate(void)
 */
 Bool TIDY_CALL        tidySetOptionCallback( TidyDoc tdoc, TidyOptCallback pOptCallback )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
+  if ( tdoc )
   {
-    impl->pOptCallback = pOptCallback;
+    tdoc->pOptCallback = pOptCallback;
     return yes;
   }
   return no;
@@ -190,58 +184,53 @@ Bool TIDY_CALL        tidySetOptionCallback( TidyDoc tdoc, TidyOptCallback pOptC
 
 int TIDY_CALL     tidyLoadConfig( TidyDoc tdoc, ctmbstr cfgfil )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(ParseConfigFile)( impl, cfgfil );
+    if ( tdoc )
+        return TY_(ParseConfigFile)( tdoc, cfgfil );
     return -EINVAL;
 }
 
 int TIDY_CALL     tidyLoadConfigEnc( TidyDoc tdoc, ctmbstr cfgfil, ctmbstr charenc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(ParseConfigFileEnc)( impl, cfgfil, charenc );
+    if ( tdoc )
+        return TY_(ParseConfigFileEnc)( tdoc, cfgfil, charenc );
     return -EINVAL;
 }
 
 int TIDY_CALL         tidySetCharEncoding( TidyDoc tdoc, ctmbstr encnam )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        int enc = TY_(CharEncodingId)( impl, encnam );
-        if ( enc >= 0 && TY_(AdjustCharEncoding)(impl, enc) )
+        int enc = TY_(CharEncodingId)( tdoc, encnam );
+        if ( enc >= 0 && TY_(AdjustCharEncoding)(tdoc, enc) )
             return 0;
 
-        TY_(ReportBadArgument)( impl, "char-encoding" );
+        TY_(ReportBadArgument)( tdoc, "char-encoding" );
     }
     return -EINVAL;
 }
 
 int TIDY_CALL           tidySetInCharEncoding( TidyDoc tdoc, ctmbstr encnam )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        int enc = TY_(CharEncodingId)( impl, encnam );
-        if ( enc >= 0 && TY_(SetOptionInt)( impl, TidyInCharEncoding, enc ) )
+        int enc = TY_(CharEncodingId)( tdoc, encnam );
+        if ( enc >= 0 && TY_(SetOptionInt)( tdoc, TidyInCharEncoding, enc ) )
             return 0;
 
-        TY_(ReportBadArgument)( impl, "in-char-encoding" );
+        TY_(ReportBadArgument)( tdoc, "in-char-encoding" );
     }
     return -EINVAL;
 }
 
 int TIDY_CALL           tidySetOutCharEncoding( TidyDoc tdoc, ctmbstr encnam )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        int enc = TY_(CharEncodingId)( impl, encnam );
-        if ( enc >= 0 && TY_(SetOptionInt)( impl, TidyOutCharEncoding, enc ) )
+        int enc = TY_(CharEncodingId)( tdoc, encnam );
+        if ( enc >= 0 && TY_(SetOptionInt)( tdoc, TidyOutCharEncoding, enc ) )
             return 0;
 
-        TY_(ReportBadArgument)( impl, "out-char-encoding" );
+        TY_(ReportBadArgument)( tdoc, "out-char-encoding" );
     }
     return -EINVAL;
 }
@@ -256,159 +245,139 @@ TidyOptionId TIDY_CALL tidyOptGetIdForName( ctmbstr optnam )
 
 TidyIterator TIDY_CALL  tidyGetOptionList( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(getOptionList)( impl );
+    if ( tdoc )
+        return TY_(getOptionList)( tdoc );
     return (TidyIterator) -1;
 }
 
 TidyOption TIDY_CALL    tidyGetNextOption( TidyDoc tdoc, TidyIterator* pos )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     TidyOption option = NULL;
-    if ( impl )
-        option = TY_(getNextOption)( impl, pos );
+    if ( tdoc )
+        option = TY_(getNextOption)( tdoc, pos );
     else if ( pos )
         *pos = 0;
-    return tidyImplToOption( option );
+    return option;
 }
 
 
 TidyOption TIDY_CALL    tidyGetOption( TidyDoc ARG_UNUSED(tdoc), TidyOptionId optId )
 {
-    TidyOption option = TY_(getOption)( optId );
-    return tidyImplToOption( option );
+    return TY_(getOption)( optId );
 }
 TidyOption TIDY_CALL    tidyGetOptionByName( TidyDoc ARG_UNUSED(doc), ctmbstr optnam )
 {
-    TidyOption option = TY_(lookupOption)( optnam );
-    return tidyImplToOption( option );
+    return TY_(lookupOption)( optnam );
 }
 
 TidyOptionId TIDY_CALL  tidyOptGetId( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option )
-        return option->id;
+    if ( topt )
+        return topt->id;
     return N_TIDY_OPTIONS;
 }
 ctmbstr TIDY_CALL       tidyOptGetName( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option )
-        return option->name;
+    if ( topt )
+        return topt->name;
     return NULL;
 }
 TidyOptionType TIDY_CALL tidyOptGetType( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option )
-        return option->type;
+    if ( topt )
+        return topt->type;
     return (TidyOptionType) -1;
 }
 TidyConfigCategory TIDY_CALL tidyOptGetCategory( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option )
-        return option->category;
+    if ( topt )
+        return topt->category;
     return (TidyConfigCategory) -1;
 }
 ctmbstr TIDY_CALL       tidyOptGetDefault( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option && option->type == TidyString )
-        return option->pdflt; /* Issue #306 - fix an old typo hidden by a cast! */
+    if ( topt && topt->type == TidyString )
+        return topt->pdflt; /* Issue #306 - fix an old typo hidden by a cast! */
     return NULL;
 }
 ulong TIDY_CALL          tidyOptGetDefaultInt( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option && option->type != TidyString )
-        return option->dflt;
+    if ( topt && topt->type != TidyString )
+        return topt->dflt;
     return ~0U;
 }
 Bool TIDY_CALL          tidyOptGetDefaultBool( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option && option->type != TidyString )
-        return ( option->dflt ? yes : no );
+    if ( topt && topt->type != TidyString )
+        return ( topt->dflt ? yes : no );
     return no;
 }
 Bool TIDY_CALL          tidyOptIsReadOnly( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option  )
-        return ( option->parser == NULL );
+    if ( topt  )
+        return ( topt->parser == NULL );
     return yes;
 }
 
 
 TidyIterator TIDY_CALL  tidyOptGetPickList( TidyOption topt )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option )
-      return TY_(getOptionPickList)( option );
+    if ( topt )
+      return TY_(getOptionPickList)( topt );
     return (TidyIterator) -1;
 }
 ctmbstr TIDY_CALL       tidyOptGetNextPick( TidyOption topt, TidyIterator* pos )
 {
-    TidyOption option = tidyOptionToImpl( topt );
-    if ( option )
-        return TY_(getNextOptionPick)( option, pos );
+    if ( topt )
+        return TY_(getNextOptionPick)( topt, pos );
     return NULL;
 }
 
 
 ctmbstr TIDY_CALL       tidyOptGetValue( TidyDoc tdoc, TidyOptionId optId )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
   ctmbstr optval = NULL;
-  if ( impl )
-    optval = cfgStr( impl, optId );
+  if ( tdoc )
+    optval = cfgStr( tdoc, optId );
   return optval;
 }
 Bool TIDY_CALL        tidyOptSetValue( TidyDoc tdoc, TidyOptionId optId, ctmbstr val )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
-    return TY_(ParseConfigValue)( impl, optId, val );
+  if ( tdoc )
+    return TY_(ParseConfigValue)( tdoc, optId, val );
   return no;
 }
 Bool TIDY_CALL        tidyOptParseValue( TidyDoc tdoc, ctmbstr optnam, ctmbstr val )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
-    return TY_(ParseConfigOption)( impl, optnam, val );
+  if ( tdoc )
+    return TY_(ParseConfigOption)( tdoc, optnam, val );
   return no;
 }
 
 ulong TIDY_CALL        tidyOptGetInt( TidyDoc tdoc, TidyOptionId optId )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     ulong opti = 0;
-    if ( impl )
-        opti = cfg( impl, optId );
+    if ( tdoc )
+        opti = cfg( tdoc, optId );
     return opti;
 }
 
 Bool TIDY_CALL        tidyOptSetInt( TidyDoc tdoc, TidyOptionId optId, ulong val )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(SetOptionInt)( impl, optId, val );
+    if ( tdoc )
+        return TY_(SetOptionInt)( tdoc, optId, val );
     return no;
 }
 
 Bool TIDY_CALL         tidyOptGetBool( TidyDoc tdoc, TidyOptionId optId )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     Bool optb = no;
-    if ( impl )
+    if ( tdoc )
     {
         TidyOption option = TY_(getOption)( optId );
         if ( option )
         {
-            optb = cfgBool( impl, optId );
+            optb = cfgBool( tdoc, optId );
         }
     }
     return optb;
@@ -416,9 +385,8 @@ Bool TIDY_CALL         tidyOptGetBool( TidyDoc tdoc, TidyOptionId optId )
 
 Bool TIDY_CALL        tidyOptSetBool( TidyDoc tdoc, TidyOptionId optId, Bool val )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(SetOptionBool)( impl, optId, val );
+    if ( tdoc )
+        return TY_(SetOptionBool)( tdoc, optId, val );
     return no;
 }
 
@@ -446,19 +414,17 @@ ctmbstr TIDY_CALL       tidyOptGetCurrPick( TidyDoc tdoc, TidyOptionId optId )
 
 TidyIterator TIDY_CALL tidyOptGetDeclTagList( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     TidyIterator declIter = 0;
-    if ( impl )
-        declIter = TY_(GetDeclaredTagList)( impl );
+    if ( tdoc )
+        declIter = TY_(GetDeclaredTagList)( tdoc );
     return declIter;
 }
 
 ctmbstr TIDY_CALL       tidyOptGetNextDeclTag( TidyDoc tdoc, TidyOptionId optId,
                                      TidyIterator* iter )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     ctmbstr tagnam = NULL;
-    if ( impl )
+    if ( tdoc )
     {
         UserTagType tagtyp = tagtype_null;
         if ( optId == TidyInlineTags )
@@ -470,7 +436,7 @@ ctmbstr TIDY_CALL       tidyOptGetNextDeclTag( TidyDoc tdoc, TidyOptionId optId,
         else if ( optId == TidyPreTags )
             tagtyp = tagtype_pre;
         if ( tagtyp != tagtype_null )
-            tagnam = TY_(GetNextDeclaredTag)( impl, tagtyp, iter );
+            tagnam = TY_(GetNextDeclaredTag)( tdoc, tagtyp, iter );
     }
     return tagnam;
 }
@@ -509,46 +475,41 @@ TidyOption TIDY_CALL tidyOptGetNextDocLinks( TidyDoc tdoc, TidyIterator* pos )
 
 int TIDY_CALL tidyOptSaveFile( TidyDoc tdoc, ctmbstr cfgfil )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(SaveConfigFile)( impl, cfgfil );
+    if ( tdoc )
+        return TY_(SaveConfigFile)( tdoc, cfgfil );
     return -EINVAL;
 }
 
 int TIDY_CALL tidyOptSaveSink( TidyDoc tdoc, TidyOutputSink* sink )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(SaveConfigSink)( impl, sink );
+    if ( tdoc )
+        return TY_(SaveConfigSink)( tdoc, sink );
     return -EINVAL;
 }
 
 Bool TIDY_CALL tidyOptSnapshot( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        TY_(TakeConfigSnapshot)( impl );
+        TY_(TakeConfigSnapshot)( tdoc );
         return yes;
     }
     return no;
 }
 Bool TIDY_CALL tidyOptResetToSnapshot( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        TY_(ResetConfigToSnapshot)( impl );
+        TY_(ResetConfigToSnapshot)( tdoc );
         return yes;
     }
     return no;
 }
 Bool TIDY_CALL tidyOptResetAllToDefault( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        TY_(ResetConfigToDefault)( impl );
+        TY_(ResetConfigToDefault)( tdoc );
         return yes;
     }
     return no;
@@ -556,34 +517,29 @@ Bool TIDY_CALL tidyOptResetAllToDefault( TidyDoc tdoc )
 
 Bool TIDY_CALL tidyOptResetToDefault( TidyDoc tdoc, TidyOptionId optId )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(ResetOptionToDefault)( impl, optId );
+    if ( tdoc )
+        return TY_(ResetOptionToDefault)( tdoc, optId );
     return no;
 }
 
 Bool TIDY_CALL tidyOptDiffThanDefault( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(ConfigDiffThanDefault)( impl );
+    if ( tdoc )
+        return TY_(ConfigDiffThanDefault)( tdoc );
     return no;
 }
 Bool TIDY_CALL          tidyOptDiffThanSnapshot( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        return TY_(ConfigDiffThanSnapshot)( impl );
+    if ( tdoc )
+        return TY_(ConfigDiffThanSnapshot)( tdoc );
     return no;
 }
 
 Bool TIDY_CALL tidyOptCopyConfig( TidyDoc to, TidyDoc from )
 {
-    TidyDoc docTo = tidyDocToImpl( to );
-    TidyDoc docFrom = tidyDocToImpl( from );
-    if ( docTo && docFrom )
+    if ( to && from )
     {
-        TY_(CopyConfig)( docTo, docFrom );
+        TY_(CopyConfig)( to, from );
         return yes;
     }
     return no;
@@ -609,10 +565,9 @@ Bool TIDY_CALL tidyOptCopyConfig( TidyDoc to, TidyDoc from )
 */
 Bool TIDY_CALL        tidySetReportFilter( TidyDoc tdoc, TidyReportFilter filt )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
+  if ( tdoc )
   {
-    impl->mssgFilt = filt;
+    tdoc->mssgFilt = filt;
     return yes;
   }
   return no;
@@ -625,10 +580,9 @@ Bool TIDY_CALL        tidySetReportFilter( TidyDoc tdoc, TidyReportFilter filt )
 */
 Bool TIDY_CALL        tidySetReportFilter2( TidyDoc tdoc, TidyReportFilter2 filt )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
+  if ( tdoc )
   {
-    impl->mssgFilt2 = filt;
+    tdoc->mssgFilt2 = filt;
     return yes;
   }
   return no;
@@ -641,10 +595,9 @@ Bool TIDY_CALL        tidySetReportFilter2( TidyDoc tdoc, TidyReportFilter2 filt
 */
 Bool TIDY_CALL        tidySetReportFilter3( TidyDoc tdoc, TidyReportFilter3 filt )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
+  if ( tdoc )
   {
-    impl->mssgFilt3 = filt;
+    tdoc->mssgFilt3 = filt;
     return yes;
   }
   return no;
@@ -653,20 +606,18 @@ Bool TIDY_CALL        tidySetReportFilter3( TidyDoc tdoc, TidyReportFilter3 filt
 #if 0   /* Not yet */
 int         tidySetContentOutputSink( TidyDoc tdoc, TidyOutputSink* outp )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
+  if ( tdoc )
   {
-    impl->docOut = outp;
+    tdoc->docOut = outp;
     return 0;
   }
   return -EINVAL;
 }
 int         tidySetDiagnosticOutputSink( TidyDoc tdoc, TidyOutputSink* outp )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  if ( impl )
+  if ( tdoc )
   {
-    impl->msgOut = outp;
+    tdoc->msgOut = outp;
     return 0;
   }
   return -EINVAL;
@@ -677,10 +628,9 @@ int         tidySetDiagnosticOutputSink( TidyDoc tdoc, TidyOutputSink* outp )
 */
 cmbstr       tidyLookupMessage( TidyDoc tdoc, int errorNo )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
   cmbstr mssg = NULL;
-  if ( impl )
-    mssg = tidyMessage_Lookup( impl->messages, errorNo );
+  if ( tdoc )
+    mssg = tidyMessage_Lookup( tdoc->messages, errorNo );
   return mssg;
 }
 #endif
@@ -688,48 +638,45 @@ cmbstr       tidyLookupMessage( TidyDoc tdoc, int errorNo )
 
 FILE* TIDY_CALL   tidySetErrorFile( TidyDoc tdoc, ctmbstr errfilnam )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
         FILE* errout = fopen( errfilnam, "wb" );
         if ( errout )
         {
-            uint outenc = cfg( impl, TidyOutCharEncoding );
-            uint nl = cfg( impl, TidyNewline );
-            TY_(ReleaseStreamOut)( impl, impl->errout );
-            impl->errout = TY_(FileOutput)( impl, errout, outenc, nl );
+            uint outenc = cfg( tdoc, TidyOutCharEncoding );
+            uint nl = cfg( tdoc, TidyNewline );
+            TY_(ReleaseStreamOut)( tdoc, tdoc->errout );
+            tdoc->errout = TY_(FileOutput)( tdoc, errout, outenc, nl );
             return errout;
         }
         else /* Emit message to current error sink */
-            TY_(FileError)( impl, errfilnam, TidyError );
+            TY_(FileError)( tdoc, errfilnam, TidyError );
     }
     return NULL;
 }
 
 int TIDY_CALL    tidySetErrorBuffer( TidyDoc tdoc, TidyBuffer* errbuf )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        uint outenc = cfg( impl, TidyOutCharEncoding );
-        uint nl = cfg( impl, TidyNewline );
-        TY_(ReleaseStreamOut)( impl, impl->errout );
-        impl->errout = TY_(BufferOutput)( impl, errbuf, outenc, nl );
-        return ( impl->errout ? 0 : -ENOMEM );
+        uint outenc = cfg( tdoc, TidyOutCharEncoding );
+        uint nl = cfg( tdoc, TidyNewline );
+        TY_(ReleaseStreamOut)( tdoc, tdoc->errout );
+        tdoc->errout = TY_(BufferOutput)( tdoc, errbuf, outenc, nl );
+        return ( tdoc->errout ? 0 : -ENOMEM );
     }
     return -EINVAL;
 }
 
 int TIDY_CALL    tidySetErrorSink( TidyDoc tdoc, TidyOutputSink* sink )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        uint outenc = cfg( impl, TidyOutCharEncoding );
-        uint nl = cfg( impl, TidyNewline );
-        TY_(ReleaseStreamOut)( impl, impl->errout );
-        impl->errout = TY_(UserOutput)( impl, sink, outenc, nl );
-        return ( impl->errout ? 0 : -ENOMEM );
+        uint outenc = cfg( tdoc, TidyOutCharEncoding );
+        uint nl = cfg( tdoc, TidyNewline );
+        TY_(ReleaseStreamOut)( tdoc, tdoc->errout );
+        tdoc->errout = TY_(UserOutput)( tdoc, sink, outenc, nl );
+        return ( tdoc->errout ? 0 : -ENOMEM );
     }
     return -EINVAL;
 }
@@ -738,10 +685,9 @@ int TIDY_CALL    tidySetErrorSink( TidyDoc tdoc, TidyOutputSink* sink )
  */
 Bool TIDY_CALL        tidySetPrettyPrinterCallback(TidyDoc tdoc, TidyPPProgress callback)
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
+    if ( tdoc )
     {
-        impl->progressCallback = callback;
+        tdoc->progressCallback = callback;
         return yes;
     }
     return no;
@@ -751,58 +697,50 @@ Bool TIDY_CALL        tidySetPrettyPrinterCallback(TidyDoc tdoc, TidyPPProgress 
 /* Document info */
 int TIDY_CALL        tidyStatus( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     int tidyStat = -EINVAL;
-    if ( impl )
-        tidyStat = tidyDocStatus( impl );
+    if ( tdoc )
+        tidyStat = tidyDocStatus( tdoc );
     return tidyStat;
 }
 int TIDY_CALL        tidyDetectedHtmlVersion( TidyDoc ARG_UNUSED(tdoc) )
 {
-/*    TidyDoc impl = tidyDocToImpl( tdoc ); */
     return 0;
 }
 Bool TIDY_CALL        tidyDetectedXhtml( TidyDoc ARG_UNUSED(tdoc) )
 {
-/*    TidyDoc impl = tidyDocToImpl( tdoc ); */
     return no;
 }
 Bool TIDY_CALL        tidyDetectedGenericXml( TidyDoc ARG_UNUSED(tdoc) )
 {
-/*    TidyDoc impl = tidyDocToImpl( tdoc ); */
     return no;
 }
 
 uint TIDY_CALL       tidyErrorCount( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     uint count = 0xFFFFFFFF;
-    if ( impl )
-        count = impl->errors;
+    if ( tdoc )
+        count = tdoc->errors;
     return count;
 }
 uint TIDY_CALL       tidyWarningCount( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     uint count = 0xFFFFFFFF;
-    if ( impl )
-        count = impl->warnings;
+    if ( tdoc )
+        count = tdoc->warnings;
     return count;
 }
 uint TIDY_CALL       tidyAccessWarningCount( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     uint count = 0xFFFFFFFF;
-    if ( impl )
-        count = impl->accessErrors;
+    if ( tdoc )
+        count = tdoc->accessErrors;
     return count;
 }
 uint TIDY_CALL       tidyConfigErrorCount( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     uint count = 0xFFFFFFFF;
-    if ( impl )
-        count = impl->optionErrors;
+    if ( tdoc )
+        count = tdoc->optionErrors;
     return count;
 }
 
@@ -811,15 +749,13 @@ uint TIDY_CALL       tidyConfigErrorCount( TidyDoc tdoc )
 */
 void TIDY_CALL         tidyErrorSummary( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        TY_(ErrorSummary)( impl );
+    if ( tdoc )
+        TY_(ErrorSummary)( tdoc );
 }
 void TIDY_CALL         tidyGeneralInfo( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-        TY_(GeneralInfo)( impl );
+    if ( tdoc )
+        TY_(GeneralInfo)( tdoc );
 }
 
 
@@ -833,29 +769,24 @@ void TIDY_CALL         tidyGeneralInfo( TidyDoc tdoc )
 **
 ** HTML/XHTML version determined from input.
 */
-int TIDY_CALL  tidyParseFile( TidyDoc tdoc, ctmbstr filnam )
+int TIDY_CALL  tidyParseFile( TidyDoc doc, ctmbstr filnam )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocParseFile( doc, filnam );
 }
-int TIDY_CALL  tidyParseStdin( TidyDoc tdoc )
+int TIDY_CALL  tidyParseStdin( TidyDoc doc )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocParseStdin( doc );
 }
-int TIDY_CALL  tidyParseString( TidyDoc tdoc, ctmbstr content )
+int TIDY_CALL  tidyParseString( TidyDoc doc, ctmbstr content )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocParseString( doc, content );
 }
-int TIDY_CALL  tidyParseBuffer( TidyDoc tdoc, TidyBuffer* inbuf )
+int TIDY_CALL  tidyParseBuffer( TidyDoc doc, TidyBuffer* inbuf )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocParseBuffer( doc, inbuf );
 }
-int TIDY_CALL  tidyParseSource( TidyDoc tdoc, TidyInputSource* source )
+int TIDY_CALL  tidyParseSource( TidyDoc doc, TidyInputSource* source )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocParseSource( doc, source );
 }
 
@@ -948,29 +879,24 @@ int   tidyDocParseSource( TidyDoc doc, TidyInputSource* source )
 /* Print/save Functions
 **
 */
-int TIDY_CALL        tidySaveFile( TidyDoc tdoc, ctmbstr filnam )
+int TIDY_CALL        tidySaveFile( TidyDoc doc, ctmbstr filnam )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocSaveFile( doc, filnam );
 }
-int TIDY_CALL        tidySaveStdout( TidyDoc tdoc )
+int TIDY_CALL        tidySaveStdout( TidyDoc doc )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocSaveStdout( doc );
 }
-int TIDY_CALL        tidySaveString( TidyDoc tdoc, tmbstr buffer, uint* buflen )
+int TIDY_CALL        tidySaveString( TidyDoc doc, tmbstr buffer, uint* buflen )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocSaveString( doc, buffer, buflen );
 }
-int TIDY_CALL        tidySaveBuffer( TidyDoc tdoc, TidyBuffer* outbuf )
+int TIDY_CALL        tidySaveBuffer( TidyDoc doc, TidyBuffer* outbuf )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocSaveBuffer( doc, outbuf );
 }
-int TIDY_CALL        tidySaveSink( TidyDoc tdoc, TidyOutputSink* sink )
+int TIDY_CALL        tidySaveSink( TidyDoc doc, TidyOutputSink* sink )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
     return tidyDocSaveSink( doc, sink );
 }
 
@@ -1136,26 +1062,23 @@ int         tidyDocStatus( TidyDoc doc )
 
 int TIDY_CALL        tidyCleanAndRepair( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-      return tidyDocCleanAndRepair( impl );
+    if ( tdoc )
+      return tidyDocCleanAndRepair( tdoc );
     return -EINVAL;
 }
 
 int TIDY_CALL        tidyRunDiagnostics( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl )
-      return tidyDocRunDiagnostics( impl );
+    if ( tdoc )
+      return tidyDocRunDiagnostics( tdoc );
     return -EINVAL;
 }
 
 int TIDY_CALL        tidyReportDoctype( TidyDoc tdoc )
 {
     int iret = -EINVAL;
-    TidyDoc impl = tidyDocToImpl( tdoc );
-    if ( impl ) {
-      tidyDocReportDoctype( impl );
+    if ( tdoc ) {
+      tidyDocReportDoctype( tdoc );
       iret = 0;
     }
     return iret;
@@ -1994,150 +1917,130 @@ int         tidyDocSaveStream( TidyDoc doc, StreamOut* out )
 
 TidyNode TIDY_CALL   tidyGetRoot( TidyDoc tdoc )
 {
-    TidyDoc impl = tidyDocToImpl( tdoc );
     TidyNode node = NULL;
-    if ( impl )
-        node = &impl->root;
-    return tidyImplToNode( node );
+    if ( tdoc )
+        node = &tdoc->root;
+    return node;
 }
 
 TidyNode TIDY_CALL   tidyGetHtml( TidyDoc tdoc )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
   TidyNode node = NULL;
-  if ( impl )
-      node = TY_(FindHTML)( impl );
-  return tidyImplToNode( node );
+  if ( tdoc )
+      node = TY_(FindHTML)( tdoc );
+  return node;
 }
 
 TidyNode TIDY_CALL    tidyGetHead( TidyDoc tdoc )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
   TidyNode node = NULL;
-  if ( impl )
-      node = TY_(FindHEAD)( impl );
-  return tidyImplToNode( node );
+  if ( tdoc )
+      node = TY_(FindHEAD)( tdoc );
+  return node;
 }
 
 TidyNode TIDY_CALL    tidyGetBody( TidyDoc tdoc )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
   TidyNode node = NULL;
-  if ( impl )
-      node = TY_(FindBody)( impl );
-  return tidyImplToNode( node );
+  if ( tdoc )
+      node = TY_(FindBody)( tdoc );
+  return node;
 }
 
 /* parent / child */
 TidyNode TIDY_CALL    tidyGetParent( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  return tidyImplToNode( nimp->parent );
+  return tnod->parent;
 }
 TidyNode TIDY_CALL    tidyGetChild( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  return tidyImplToNode( nimp->content );
+  return tnod->content;
 }
 
 /* remove a node */
 TidyNode TIDY_CALL    tidyDiscardElement( TidyDoc tdoc, TidyNode tnod )
 {
-  TidyDoc doc = tidyDocToImpl( tdoc );
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  TidyNode next = TY_(DiscardElement)( doc, nimp );
-  return tidyImplToNode( next );
+  return TY_(DiscardElement)( tdoc, tnod );
 }
 
 /* siblings */
 TidyNode TIDY_CALL    tidyGetNext( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  return tidyImplToNode( nimp->next );
+  return tnod->next;
 }
 TidyNode TIDY_CALL    tidyGetPrev( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  return tidyImplToNode( nimp->prev );
+  return tnod->prev;
 }
 
 /* Node info */
 TidyNodeType TIDY_CALL tidyNodeGetType( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
   TidyNodeType ntyp = TidyNode_Root;
-  if ( nimp )
-    ntyp = (TidyNodeType) nimp->type;
+  if ( tnod )
+    ntyp = (TidyNodeType) tnod->type;
   return ntyp;
 }
 
 uint TIDY_CALL tidyNodeLine( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
   uint line = 0;
-  if ( nimp )
-    line = nimp->line;
+  if ( tnod )
+    line = tnod->line;
   return line;
 }
 uint TIDY_CALL tidyNodeColumn( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
   uint col = 0;
-  if ( nimp )
-    col = nimp->column;
+  if ( tnod )
+    col = tnod->column;
   return col;
 }
 
 ctmbstr TIDY_CALL        tidyNodeGetName( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
   ctmbstr nnam = NULL;
-  if ( nimp )
-    nnam = nimp->element;
+  if ( tnod )
+    nnam = tnod->element;
   return nnam;
 }
 
 
 Bool TIDY_CALL  tidyNodeHasText( TidyDoc tdoc, TidyNode tnod )
 {
-  TidyDoc doc = tidyDocToImpl( tdoc );
-  if ( doc )
-      return TY_(nodeHasText)( doc, tidyNodeToImpl(tnod) );
+  if ( tdoc )
+      return TY_(nodeHasText)( tdoc, tnod );
   return no;
 }
 
 
 Bool TIDY_CALL  tidyNodeGetText( TidyDoc tdoc, TidyNode tnod, TidyBuffer* outbuf )
 {
-  TidyDoc doc = tidyDocToImpl( tdoc );
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  if ( doc && nimp && outbuf )
+  if ( tdoc && tnod && outbuf )
   {
-      uint outenc     = cfg( doc, TidyOutCharEncoding );
-      uint nl         = cfg( doc, TidyNewline );
-      StreamOut* out  = TY_(BufferOutput)( doc, outbuf, outenc, nl );
-      Bool xmlOut     = cfgBool( doc, TidyXmlOut );
-      Bool xhtmlOut   = cfgBool( doc, TidyXhtmlOut );
+      uint outenc     = cfg( tdoc, TidyOutCharEncoding );
+      uint nl         = cfg( tdoc, TidyNewline );
+      StreamOut* out  = TY_(BufferOutput)( tdoc, outbuf, outenc, nl );
+      Bool xmlOut     = cfgBool( tdoc, TidyXmlOut );
+      Bool xhtmlOut   = cfgBool( tdoc, TidyXhtmlOut );
 
-      doc->docOut = out;
+      tdoc->docOut = out;
       if ( xmlOut && !xhtmlOut )
-          TY_(PPrintXMLTree)( doc, NORMAL, 0, nimp );
+          TY_(PPrintXMLTree)( tdoc, NORMAL, 0, tnod );
       else
-          TY_(PPrintTree)( doc, NORMAL, 0, nimp );
+          TY_(PPrintTree)( tdoc, NORMAL, 0, tnod );
 
-      TY_(PFlushLine)( doc, 0 );
-      doc->docOut = NULL;
+      TY_(PFlushLine)( tdoc, 0 );
+      tdoc->docOut = NULL;
 
-      TidyDocFree( doc, out );
+      TidyDocFree( tdoc, out );
       return yes;
   }
   return no;
 }
 
-Bool TIDY_CALL tidyNodeGetValue( TidyDoc tdoc, TidyNode tnod, TidyBuffer* buf )
+Bool TIDY_CALL tidyNodeGetValue( TidyDoc doc, TidyNode node, TidyBuffer* buf )
 {
-    TidyDoc doc = tidyDocToImpl( tdoc );
-    TidyNode node = tidyNodeToImpl( tnod );
     if ( doc == NULL || node == NULL || buf == NULL )
         return no;
 
@@ -2166,11 +2069,10 @@ Bool TIDY_CALL tidyNodeGetValue( TidyDoc tdoc, TidyNode tnod, TidyBuffer* buf )
 
 Bool TIDY_CALL tidyNodeIsProp( TidyDoc ARG_UNUSED(tdoc), TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
   Bool isProprietary = yes;
-  if ( nimp )
+  if ( tnod )
   {
-    switch ( nimp->type )
+    switch ( tnod->type )
     {
     case RootNode:
     case DocTypeTag:
@@ -2192,8 +2094,8 @@ Bool TIDY_CALL tidyNodeIsProp( TidyDoc ARG_UNUSED(tdoc), TidyNode tnod )
     case StartTag:
     case EndTag:
     case StartEndTag:
-        isProprietary = ( nimp->tag
-                          ? (nimp->tag->versions&VERS_PROPRIETARY)!=0
+        isProprietary = ( tnod->tag
+                          ? (tnod->tag->versions&VERS_PROPRIETARY)!=0
                           : yes );
         break;
     }
@@ -2203,11 +2105,10 @@ Bool TIDY_CALL tidyNodeIsProp( TidyDoc ARG_UNUSED(tdoc), TidyNode tnod )
 
 TidyTagId TIDY_CALL tidyNodeGetId(TidyNode tnod)
 {
-    TidyNode nimp = tidyNodeToImpl(tnod);
 
     TidyTagId tagId = TidyTag_UNKNOWN;
-    if (nimp && nimp->tag)
-        tagId = nimp->tag->id;
+    if (tnod && tnod->tag)
+        tagId = tnod->tag->id;
 
     return tagId;
 }
@@ -2228,44 +2129,37 @@ cmbstr       tidyNodeNsUri( TidyNode tnod )
 /* Iterate over attribute values */
 TidyAttr TIDY_CALL   tidyAttrFirst( TidyNode tnod )
 {
-  TidyNode nimp = tidyNodeToImpl( tnod );
   TidyAttr attval = NULL;
-  if ( nimp )
-    attval = nimp->attributes;
-  return tidyImplToAttr( attval );
+  if ( tnod )
+    attval = tnod->attributes;
+  return attval;
 }
 TidyAttr TIDY_CALL    tidyAttrNext( TidyAttr tattr )
 {
-  TidyAttr attval = tidyAttrToImpl( tattr );
   TidyAttr nxtval = NULL;
-  if ( attval )
-    nxtval = attval->next;
-  return tidyImplToAttr( nxtval );
+  if ( tattr )
+    nxtval = tattr->next;
+  return nxtval;
 }
 
 ctmbstr TIDY_CALL       tidyAttrName( TidyAttr tattr )
 {
-  TidyAttr attval = tidyAttrToImpl( tattr );
   ctmbstr anam = NULL;
-  if ( attval )
-    anam = attval->attribute;
+  if ( tattr )
+    anam = tattr->attribute;
   return anam;
 }
 ctmbstr TIDY_CALL       tidyAttrValue( TidyAttr tattr )
 {
-  TidyAttr attval = tidyAttrToImpl( tattr );
   ctmbstr aval = NULL;
-  if ( attval )
-    aval = attval->value;
+  if ( tattr )
+    aval = tattr->value;
   return aval;
 }
 
 void TIDY_CALL           tidyAttrDiscard( TidyDoc tdoc, TidyNode tnod, TidyAttr tattr )
 {
-  TidyDoc impl = tidyDocToImpl( tdoc );
-  TidyNode nimp = tidyNodeToImpl( tnod );
-  TidyAttr attval = tidyAttrToImpl( tattr );
-  TY_(RemoveAttribute)( impl, nimp, attval );
+  TY_(RemoveAttribute)( tdoc, tnod, tattr );
 }
 
 /* Null for pure HTML
@@ -2282,10 +2176,9 @@ ctmbstr       tidyAttrNsUri( TidyAttr tattr )
 
 TidyAttrId TIDY_CALL tidyAttrGetId( TidyAttr tattr )
 {
-  TidyAttr attval = tidyAttrToImpl( tattr );
   TidyAttrId attrId = TidyAttr_UNKNOWN;
-  if ( attval && attval->dict )
-    attrId = attval->dict->id;
+  if ( tattr && tattr->dict )
+    attrId = tattr->dict->id;
   return attrId;
 }
 Bool TIDY_CALL tidyAttrIsProp( TidyAttr tattr )


### PR DESCRIPTION
As discussed in #409, these changes turn the separate set of opaque types into equally opaque pointers to incomplete structures (i.e. declarations without definitions), with the complete definition added internally. In other words, the public API still doesn't know about the internal structure of any of these objects, but the tidy code can transparently operate them without any need to convert back and forth. As a consequence, the code allows more robust type-checking, is shorter and easier to read. Currently this diff removes 194 lines. There probably is some room for further improvements, since many of the public API functions are now just aliases for some private function, so that in a later commit we could eliminate the private names and instead implement the public functions directly. But the diff is long enough as it is, so I'll not do that just now.

`TidyIterator` doesn't actually name a single structure.  Often it's not a pointer at all, but an integer instead. So that will still be dealt with as before.

The `TidyOption` definition is somewhat special as well, since it contains the const qualifier, and the name of the structure doesn't follow the common schema. For that reason it doesn't make use of the `opaque_type` macro.