### PR TITLE
Add compatibility headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,12 @@ set ( CFILES
 set ( HFILES
         ${INCDIR}/tidyplatform.h ${INCDIR}/tidy.h         ${INCDIR}/tidyenum.h
         ${INCDIR}/tidybuffio.h )
+
+option (TIDY_COMPAT_HEADERS "If set to ON, compatability headers are included" OFF)
+if (TIDY_COMPAT_HEADERS)
+    set ( HFILES ${HFILES}      ${INCDIR}/buffio.h        ${INCDIR}/platform.h )
+endif ()
+
 set ( LIBHFILES
         ${SRCDIR}/access.h       ${SRCDIR}/attrs.h        ${SRCDIR}/attrdict.h ${SRCDIR}/charsets.h
         ${SRCDIR}/clean.h        ${SRCDIR}/config.h       ${SRCDIR}/entities.h

--- a/include/buffio.h
+++ b/include/buffio.h
@@ -1,0 +1,6 @@
+#ifdef __GNUC__
+#warning "FIXME: Using compatibility tidy header (buffio.h) that will go away!"
+#endif
+
+#include "tidybuffio.h"
+

--- a/include/platform.h
+++ b/include/platform.h
@@ -1,0 +1,6 @@
+#ifdef __GNUC__
+#warning "FIXME: Using compatibility tidy header (platform.h) that will go away!"
+#endif
+
+#include "tidyplatform.h"
+


### PR DESCRIPTION
In older versions of tidy, these headers were defined. Now, they are
renamed to tidybuffio.h and tidyplatform.h. This may be more of a
consistent naming scheme, but it breaks current software.

Re-add these headers and add compile time warning when such a header
is used.