### PR TITLE
prevent buffer overflow in debug output

### DIFF
--- a/src/sprtf.c
+++ b/src/sprtf.c
@@ -395,7 +395,7 @@ int MCDECL sprtf( const char *pf, ... )
    int   i;
    va_list arglist;
    va_start(arglist, pf);
-   i = vsprintf( pb, pf, arglist );
+   i = vsnprintf( pb, M_MAX_SPRTF, pf, arglist );
    va_end(arglist);
 #ifdef _MSC_VER
    prt(pb); // ensure CR/LF


### PR DESCRIPTION
This simple modification prevents a buffer overflow in debug output. Some debug output are larger than the defined `M_MAX_SPRTF`. `vsnprintf` checks the spezified size.