### PR TITLE
Set HAS_FUTIME=0 on any GNU libc platform

### DIFF
--- a/include/tidyplatform.h
+++ b/include/tidyplatform.h
@@ -406,7 +406,7 @@ extern "C" {
 #if PRESERVE_FILE_TIMES
 
 #ifndef HAS_FUTIME
-#if defined(CYGWIN_OS) || defined(BE_OS) || defined(OS2_OS) || defined(HPUX_OS) || defined(SOLARIS_OS) || defined(LINUX_OS) || defined(BSD_BASED_OS) || defined(MAC_OS) || defined(__MSL__) || defined(IRIX_OS) || defined(AIX_OS) || defined(__BORLANDC__)
+#if defined(CYGWIN_OS) || defined(BE_OS) || defined(OS2_OS) || defined(HPUX_OS) || defined(SOLARIS_OS) || defined(LINUX_OS) || defined(BSD_BASED_OS) || defined(MAC_OS) || defined(__MSL__) || defined(IRIX_OS) || defined(AIX_OS) || defined(__BORLANDC__) || defined(__GLIBC__)
 #define HAS_FUTIME 0
 #else
 #define HAS_FUTIME 1


### PR DESCRIPTION
GNU libc does not have `<sys/utime.h>` but `<utime.h>`, so set `HAS_FUTIME=0` for it; fixes build on non-Linux platforms using GNU libc.