### PR TITLE
Avoid crash in tidyCleanAndRepair if document was not loaded

### DIFF
--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1908,9 +1908,11 @@ int         tidyDocCleanAndRepair( TidyDocImpl* doc )
        it can ever be, so we can start detecting things that shouldn't
        be in this version of HTML
      */
-    if (doc->lexer->versionEmitted & VERS_HTML5)
-         TY_(CheckHTML5)( doc, &doc->root );
-    TY_(CheckHTMLTagsAttribsVersions)( doc, &doc->root );
+    if (doc->root.content) {
+        if (doc->lexer->versionEmitted & VERS_HTML5)
+             TY_(CheckHTML5)( doc, &doc->root );
+        TY_(CheckHTMLTagsAttribsVersions)( doc, &doc->root );
+    }
 
 #if !defined(NDEBUG) && defined(_MSC_VER)
     SPRTF("All nodes AFTER clean and repair\n");


### PR DESCRIPTION
This can happen after attempt to load nonexisting file.

This used to work fine with old libtidy, but no longer works with html-tidy, so I think it is a regression. I'm not sure the fix is really correct, but it seems to do what is expected for me.