### PR TITLE
Add support for the "integrity" attribute

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -846,6 +846,8 @@ typedef enum
   TidyAttr_TYPEOF,            /**< TYPEOF= */
   TidyAttr_VOCAB,             /**< VOCAB= */
 
+  TidyAttr_INTEGRITY,         /**< INTEGRITY= */
+
   N_TIDY_ATTRIBS              /**< Must be last */
 } TidyAttrId;
 

--- a/src/attrdict.c
+++ b/src/attrdict.c
@@ -1957,6 +1957,7 @@ const AttrVersion TY_(W3CAttrsFor_LINK)[] =
   { TidyAttr_HREF,                  HT20|HT32|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|HT50|XH50 },
   { TidyAttr_HREFLANG,              xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|HT50|XH50 },
   { TidyAttr_ID,                    xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|HT50|XH50 }, /* CORE override */
+  { TidyAttr_INTEGRITY,             xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_LANG,                  xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|xxxx|xxxx|HT50|XH50 }, /* CORE override */
   { TidyAttr_MEDIA,                 xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|HT50|XH50 },
   { TidyAttr_METHODS,               HT20|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx },
@@ -2784,6 +2785,7 @@ const AttrVersion TY_(W3CAttrsFor_SCRIPT)[] =
   { TidyAttr_EVENT,                 xxxx|xxxx|H40T|H41T|xxxx|H40F|H41F|xxxx|H40S|H41S|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_FOR,                   xxxx|xxxx|H40T|H41T|xxxx|H40F|H41F|xxxx|H40S|H41S|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_ID,                    xxxx|xxxx|xxxx|xxxx|X10T|xxxx|xxxx|X10F|xxxx|xxxx|X10S|xxxx|xxxx|HT50|XH50 }, /* CORE override */
+  { TidyAttr_INTEGRITY,             xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_LANGUAGE,              xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_SRC,                   xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|xxxx|HT50|XH50 },
   { TidyAttr_TYPE,                  xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|xxxx|HT50|XH50 },

--- a/src/attrs.c
+++ b/src/attrs.c
@@ -438,6 +438,8 @@ static const Attribute attribute_defs [] =
   { TidyAttr_TYPEOF,                   "typeof",                 CH_RDFATERMS  },
   { TidyAttr_VOCAB,                    "vocab",                  CH_URL        },
 
+  { TidyAttr_INTEGRITY,                "integrity",              CH_PCDATA   },
+
   /* this must be the final entry */
   { N_TIDY_ATTRIBS,                    NULL,                     NULL         }
 };


### PR DESCRIPTION
This attribute may be used on "link" and "script" elements. See [the subresource integrity spec](http://www.w3.org/TR/2016/REC-SRI-20160623/#element-interface-extensions).

This fixes #441.