### PR TITLE
style: ansi conforming comments

### DIFF
--- a/console/tidy.c
+++ b/console/tidy.c
@@ -1105,18 +1105,18 @@ static tmbstr cleanup_description( ctmbstr description )
 
     /* Output Setup */
     tmbstr result = NULL;
-    int g_result = 100;  // minimum buffer grow size
-    int l_result = 0;    // buffer current size
-    int i_result = 0;    // current string position
-    int writer_len = 0;  // writer length
+    int g_result = 100;  /* minimum buffer grow size */
+    int l_result = 0;    /* buffer current size */
+    int i_result = 0;    /* current string position */
+    int writer_len = 0;  /* writer length */
 
     ctmbstr writer = NULL;
 
     /* Current tag name setup */
-    tmbstr name = NULL; // tag name
-    int g_name = 10;    // buffer grow size
-    int l_name = 0;     // buffer current size
-    int i_name = 0;     // current string position
+    tmbstr name = NULL; /* tag name */
+    int g_name = 10;    /* buffer grow size */
+    int l_name = 0;     /* buffer current size */
+    int i_name = 0;     /* current string position */
 
     /* Pump Setup */
     int i = 0;
@@ -1189,7 +1189,7 @@ static tmbstr cleanup_description( ctmbstr description )
                          ensure that `writer` is NULL as a flag that we
                          will output the current `c` */
                     case a_EMIT:
-                        writer = NULL; // flag to use c
+                        writer = NULL; /* flag to use c */
                         break;
 
                         /* Now that we've consumed a tag, we will emit the
@@ -1552,7 +1552,7 @@ int main( int argc, char** argv )
 
 #if !defined(NDEBUG) && defined(_MSC_VER)
     set_log_file((char *)"temptidy.txt", 0);
-    // add_append_log(1);
+    /* add_append_log(1); */
 #endif
 
     /*
@@ -1936,7 +1936,7 @@ int main( int argc, char** argv )
             htmlfil = argv[1];
 #if (!defined(NDEBUG) && defined(_MSC_VER))
             SPRTF("Tidying '%s'\n", htmlfil);
-#endif // DEBUG outout
+#endif /* DEBUG outout */
             if ( tidyOptGetBool(tdoc, TidyEmacs) )
                 tidyOptSetValue( tdoc, TidyEmacsFile, htmlfil );
             status = tidyParseFile( tdoc, htmlfil );

--- a/experimental/TidyNodeIter.c
+++ b/experimental/TidyNodeIter.c
@@ -18,21 +18,21 @@ Node *nextTidyNode( TidyNodeIter *pThis )
 {
     if (NULL == pThis->pCurrent)
     {
-        // just starting out, initialize
+        /* just starting out, initialize */
         pThis->pCurrent = pThis->pTop->content;
     }
     else if (NULL != pThis->pCurrent->content)
     {
-        // the next element, if any, is my first-born child
+        /* the next element, if any, is my first-born child */
         pThis->pCurrent = pThis->pCurrent->content;
     }
     else 
     {
-        // no children, I guess my next younger brother inherits the throne.
+        /* no children, I guess my next younger brother inherits the throne. */
         while (   NULL == pThis->pCurrent->next
                && pThis->pTop != pThis->pCurrent->parent )
         {
-            //  no siblings, do any of my ancestors have younger sibs?
+            /* no siblings, do any of my ancestors have younger sibs? */
             pThis->pCurrent = pThis->pCurrent->parent;
         }
         pThis->pCurrent = pThis->pCurrent->next;

--- a/experimental/httpio.h
+++ b/experimental/httpio.h
@@ -19,7 +19,7 @@
 TIDY_STRUCT
 typedef struct _HTTPInputSource
 {
-    TidyInputSource tis;    //  This declaration must be first and must not be changed!
+    TidyInputSource tis; /* This declaration must be first and must not be changed! */
 
     tmbstr pHostName;
     tmbstr pResource;

--- a/include/tidy.h
+++ b/include/tidy.h
@@ -996,7 +996,7 @@ TIDY_EXPORT Bool TIDY_CALL tidyNodeIsU( TidyNode tnod );
 TIDY_EXPORT Bool TIDY_CALL tidyNodeIsMENU( TidyNode tnod );
 
 /* HTML5 */
-TIDY_EXPORT Bool TIDY_CALL tidyNodeIsDATALIST( TidyNode tnod ); // bit like OPTIONS
+TIDY_EXPORT Bool TIDY_CALL tidyNodeIsDATALIST( TidyNode tnod ); /* bit like OPTIONS */
 
 
 /** @} End NodeIsElementName group */

--- a/src/clean.c
+++ b/src/clean.c
@@ -1007,7 +1007,7 @@ static Bool Center2Div( TidyDocImpl* doc, Node *node, Node **pnode)
 {
     if ( nodeIsCENTER(node) )
     {
-#if 0 // 00000000 what is this doing inside an nodeIsCENTER(node)??? 0000000
+#if 0 /* 00000000 what is this doing inside an nodeIsCENTER(node)??? 0000000 */
         if ( cfgBool(doc, TidyDropFontTags) )
         {
             if (node->content)
@@ -1035,7 +1035,7 @@ static Bool Center2Div( TidyDocImpl* doc, Node *node, Node **pnode)
 
             return yes;
         }
-#endif // 00000000 what is this doing inside an nodeIsCENTER(node)??? 0000000
+#endif /* 00000000 what is this doing inside an nodeIsCENTER(node)??? 0000000 */
         RenameElem( doc, node, TidyTag_DIV );
         TY_(AddStyleProperty)( doc, node, "text-align: center" );
         return yes;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -143,9 +143,9 @@ static void Show_Node( TidyDocImpl* doc, const char *msg, Node *node )
     int col  = ( doc->lexer ? doc->lexer->columns : 0 );
     tmbstr src = lex ? "lexer" : "stream";
     SPRTF("R=%d C=%d: ", line, col );
-    // DEBUG: Be able to set a TRAP on a SPECIFIC row,col
+    /* DEBUG: Be able to set a TRAP on a SPECIFIC row,col */
     if ((line == 67) && (col == 95)) {
-        check_me("Show_Node"); // just a debug trap
+        check_me("Show_Node"); /* just a debug trap */
     }
     if (lexer && lexer->token && 
         ((lexer->token->type == TextNode)||(node && (node->type == TextNode)))) {

--- a/src/tags.c
+++ b/src/tags.c
@@ -301,7 +301,7 @@ static Dict tag_defs[] =
   { TidyTag_CANVAS,      "canvas",       VERS_ELEM_CANVAS,      &TY_(W3CAttrsFor_CANVAS)[0],      (CM_BLOCK),                    TY_(ParseBlock),     NULL           },
   { TidyTag_COMMAND,     "command",      VERS_ELEM_COMMAND,     &TY_(W3CAttrsFor_COMMAND)[0],     (CM_HEAD|CM_INLINE|CM_EMPTY),  TY_(ParseEmpty),     NULL           },
   { TidyTag_DATALIST,    "datalist",     VERS_ELEM_DATALIST,    &TY_(W3CAttrsFor_DATALIST)[0],    (CM_INLINE|CM_FIELD),          TY_(ParseDatalist),  NULL           },
-  //{ TidyTag_DATALIST,    "datalist",     VERS_ELEM_DATALIST,    &TY_(W3CAttrsFor_DATALIST)[0],    (CM_FIELD),                   TY_(ParseInline),    NULL           },
+  /* { TidyTag_DATALIST,    "datalist",     VERS_ELEM_DATALIST,    &TY_(W3CAttrsFor_DATALIST)[0],    (CM_FIELD),                   TY_(ParseInline),    NULL           },*/
   { TidyTag_DETAILS,     "details",      VERS_ELEM_DETAILS,     &TY_(W3CAttrsFor_DETAILS)[0],     (CM_BLOCK),                    TY_(ParseBlock),     NULL           },
   { TidyTag_DIALOG,      "dialog",       VERS_ELEM_DIALOG,      &TY_(W3CAttrsFor_DIALOG)[0],      (CM_BLOCK),                    TY_(ParseBlock),     NULL           },
   { TidyTag_EMBED,       "embed",        VERS_ELEM_EMBED,       &TY_(W3CAttrsFor_EMBED)[0],       (CM_INLINE|CM_IMG|CM_EMPTY),   TY_(ParseEmpty),     NULL           },


### PR DESCRIPTION
Makes compiling a little bit less noisy when compiling on *nix with `-ansi` option is set. Also now adheres to projects commenting conventions. 
