### PR TITLE
Add optional xmlns:xlink attributes as valid to support inline svg

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -808,6 +808,8 @@ typedef enum
 
   TidyAttr_AS,               /**< AS= */
 
+  TidyAttr_XMLNSXLINK,        /**< svg xmls:xlink="url" */
+
   N_TIDY_ATTRIBS              /**< Must be last */
 } TidyAttrId;
 

--- a/src/attrdict.c
+++ b/src/attrdict.c
@@ -3086,6 +3086,10 @@ const AttrVersion TY_(W3CAttrsFor_SVG)[] =
   { TidyAttr_WIDTH,                 xxxx|HT32|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|HT50|XH50 },
   { TidyAttr_XML_LANG,              xxxx|xxxx|xxxx|xxxx|X10T|xxxx|xxxx|X10F|xxxx|xxxx|X10S|XH11|xxxx|HT50|XH50 }, /* CORE override */
   { TidyAttr_XMLNS,                 xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|XH11|xxxx|HT50|XH50 }, /* CORE override */
+
+  /* svg xmln:xlink=uri */
+  { TidyAttr_XMLNSXLINK,            xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|XH11|xxxx|HT50|XH50 },
+
   { TidyAttr_X,                     xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|H41S|X10S|XH11|xxxx|HT50|XH50 },
   { TidyAttr_Y,                     xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|H41S|X10S|XH11|xxxx|HT50|XH50 },
   { TidyAttr_VIEWBOX,               xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|H41S|X10S|XH11|xxxx|HT50|XH50 },

--- a/src/attrs.c
+++ b/src/attrs.c
@@ -443,6 +443,9 @@ static const Attribute attribute_defs [] =
   /* Preload spec: https://www.w3.org/TR/preload/ */
   { TidyAttr_AS,                       "as",                     CH_PCDATA   },
 
+  /* for xmlns:xlink in <svg> */
+  { TidyAttr_XMLNSXLINK,                "xmlns:xlink",           CH_URL       },
+
   /* this must be the final entry */
   { N_TIDY_ATTRIBS,                    NULL,                     NULL         }
 };


### PR DESCRIPTION
Add `xmlns:xlink` support as instructed by @geoffmcl.

I tested this build in debian docker container and the earlier false positive warning about`xmlns:xlink` being proprietary went away.

This fixes #478.