### PR TITLE
Pretty up output of empty script tags.

### DIFF
--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2000,7 +2000,11 @@ void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *node )
 
     PPrintTag( doc, mode, indent, node );
 
-    TY_(PFlushLineSmart)(doc, indent);
+    /* SCRIPT may have no content such as when loading code via its SRC attribute.
+       In this case we don't want to flush the line, preferring to keep the required
+       closing SCRIPT tag on the same line. */
+    if ( node->content != NULL )
+        TY_(PFlushLineSmart)(doc, indent);
 
     if ( xhtmlOut && node->content != NULL )
     {
@@ -2053,7 +2057,9 @@ void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *node )
             contentIndent = TextEndsWithNewline( doc->lexer, content, CDATA );
     }
 
-    if ( contentIndent < 0 )
+    /* Only flush the line if these was content present so that the closing
+       SCRIPT tag will stay on the same line. */
+    if ( contentIndent < 0 && node->content != NULL )
     {
         PCondFlushLineSmart( doc, indent );
         contentIndent = 0;


### PR DESCRIPTION
  - No longer break script tags up on two lines if there is content. However
    output is still subject to the `--wrap` behavior.
  - Previous behavior intact if there is content.

I've committed myself to tidying up the pretty-print engine a bit in order to address several feature requests, and this one addresses a piece of low-hanging fruit without being intrusive.

Specifically some users are tying to pass so-call AMP validation, something Google is promoting for fast websites. Current handling of empty `<script>` tags always break them into two lines, e.g.,

~~~
<script ...>
</script>
~~~

This patch ensures they will remain on a single line.

I've not bumped the version number, and despite the commit comment I won't assign a new configuration option for this purely visual change. 

Comments appreciated, else I'll merge it sometime soon (with a version bump).