### PR TITLE
Fix leading white spaces trimming

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -4096,7 +4096,7 @@ static tmbstr ParseValue( TidyDocImpl* doc, ctmbstr name,
             while (TY_(IsWhite)(lexer->lexbuf[start+len-1]) && (len > 0))
                 --len;
 
-            while (TY_(IsWhite)(lexer->lexbuf[start]) && (start < len) && (len > 0))
+            while (TY_(IsWhite)(lexer->lexbuf[start]) && (len > 0))
             {
                 ++start;
                 --len;


### PR DESCRIPTION
Hi!

`start` - offset in `lexer->lexbuf`
`len` - length of name

As result`len` almost always less than `start`, and leading white spaces is't trimmed