### PR TITLE
Add a flag to avoid propagating inline elements across blocks

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -580,6 +580,7 @@ typedef enum
     TidyIndentContent,           /**< Indent content of appropriate tags */
     TidyIndentSpaces,            /**< Indentation n spaces/tabs */
     TidyInlineTags,              /**< Declared inline tags */
+    TidyInsertInlineTags,        /**< Insert injected inline tags into block tags */
     TidyJoinClasses,             /**< Join multiple class attributes */
     TidyJoinStyles,              /**< Join multiple style attributes */
     TidyKeepFileTimes,           /**< If yes last modied time is preserved */

--- a/src/config.c
+++ b/src/config.c
@@ -276,7 +276,7 @@ static const TidyOptionImpl option_defs[] =
     { TidyIndentContent,           PP, "indent",                      IN, TidyNoState,     ParseAutoBool,     autoBoolPicks   },
     { TidyIndentSpaces,            PP, "indent-spaces",               IN, 2,               ParseInt,          NULL            },
     { TidyInlineTags,              MU, "new-inline-tags",             ST, 0,               ParseTagNames,     NULL            },
-    { TidyInsertInlineTags,        MU, "insert-inline-tags",          BL, no,              ParseBool,         boolPicks       },
+    { TidyInsertInlineTags,        MU, "insert-inline-tags",          BL, yes,             ParseBool,         boolPicks       },
     { TidyJoinClasses,             MU, "join-classes",                BL, no,              ParseBool,         boolPicks       },
     { TidyJoinStyles,              MU, "join-styles",                 BL, yes,             ParseBool,         boolPicks       },
     { TidyKeepFileTimes,           MS, "keep-time",                   BL, no,              ParseBool,         boolPicks       },

--- a/src/config.c
+++ b/src/config.c
@@ -276,6 +276,7 @@ static const TidyOptionImpl option_defs[] =
     { TidyIndentContent,           PP, "indent",                      IN, TidyNoState,     ParseAutoBool,     autoBoolPicks   },
     { TidyIndentSpaces,            PP, "indent-spaces",               IN, 2,               ParseInt,          NULL            },
     { TidyInlineTags,              MU, "new-inline-tags",             ST, 0,               ParseTagNames,     NULL            },
+    { TidyInsertInlineTags,        MU, "insert-inline-tags",          BL, no,              ParseBool,         boolPicks       },
     { TidyJoinClasses,             MU, "join-classes",                BL, no,              ParseBool,         boolPicks       },
     { TidyJoinStyles,              MU, "join-styles",                 BL, yes,             ParseBool,         boolPicks       },
     { TidyKeepFileTimes,           MS, "keep-time",                   BL, no,              ParseBool,         boolPicks       },

--- a/src/istack.c
+++ b/src/istack.c
@@ -215,6 +215,11 @@ Bool TY_(IsPushedLast)( TidyDocImpl* doc, Node *element, Node *node )
 */
 int TY_(InlineDup)( TidyDocImpl* doc, Node* node )
 {
+    if (!cfgBool(doc, TidyInsertInlineTags))
+    {
+        return 0;
+    }
+
     Lexer* lexer = doc->lexer;
     int n;
 

--- a/src/language_en.h
+++ b/src/language_en.h
@@ -679,6 +679,21 @@ static languageDefinition language_en = { whichPluralForm_en, {
       - It's very important that <br/> be self-closing!
       - The strings "Tidy" and "HTML Tidy" are the program name and must not
       be translated. */
+        TidyInsertInlineTags,               0,
+        "This option enables inserting \"missing\" inline elements around the "
+        "contents of blocklevel elements such as <code>P</code>, "
+        "<code>DIV</code>, etc. For instance, this causes "
+        "<code><span><div>OK</div></span></code> to become "
+        "<code><span><div><span>OK</span></div></span></code>."
+    },
+    {/* Important notes for translators:
+      - Use only <code></code>, <var></var>, <em></em>, <strong></strong>, and
+      <br/>.
+      - Entities, tags, attributes, etc., should be enclosed in <code></code>.
+      - Option values should be enclosed in <var></var>.
+      - It's very important that <br/> be self-closing!
+      - The strings "Tidy" and "HTML Tidy" are the program name and must not
+      be translated. */
         TidyJoinClasses,              0,
         "This option specifies if Tidy should combine class names to generate "
         "a single, new class name if multiple class assignments are detected on "

--- a/src/parser.c
+++ b/src/parser.c
@@ -2157,7 +2157,8 @@ void TY_(ParseInline)( TidyDocImpl* doc, Node *element, GetTokenMode mode )
          *  big consequences.
          *  There may be other exceptions to be added...
         \*/
-        if (!(node->tag->model & CM_INLINE) &&
+        if (cfgBool(doc, TidyInsertInlineTags) &&
+            !(node->tag->model & CM_INLINE) &&
             !(element->tag->model & CM_MIXED) &&
             !(nodeIsSPAN(element) && nodeIsMETA(node)) )
         {


### PR DESCRIPTION
This change adds the InsertInlineTags flag (default=on) that propagates
inline elements across block boundaries. This causes

    <span><div>OK</div></span>

to become

    <span><div><span>OK</span></div></span>

This fixes issue #461.