### PR TITLE
Fix behavior of <button> elements in HTML 5

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1442,6 +1442,22 @@ void TY_(ParseBlock)( TidyDocImpl* doc, Node *element, GetTokenMode mode)
 #endif
 }
 
+/*
+<button> changed in HTML 5. It now contains phrasing content only, rather than
+HTML4-era flow elements, which also allows for blocks.
+*/
+void TY_(ParseButton)( TidyDocImpl* doc, Node *element, GetTokenMode mode)
+{
+    if (TY_(HTMLVersion)(doc) == HT50 || TY_(HTMLVersion)(doc) == XH50)
+    {
+        TY_(ParseInline)(doc, element, mode);
+    }
+    else
+    {
+        TY_(ParseBlock)(doc, element, mode);
+    }
+}
+
 /* [i_a] svg / math */
 
 struct MatchingDescendantData

--- a/src/tags.c
+++ b/src/tags.c
@@ -184,7 +184,7 @@ static Dict tag_defs[] =
   { TidyTag_BLOCKQUOTE, "blockquote", VERS_ELEM_BLOCKQUOTE, &TY_(W3CAttrsFor_BLOCKQUOTE)[0], (CM_BLOCK),                                    TY_(ParseBlock),    NULL           },
   { TidyTag_BODY,       "body",       VERS_ELEM_BODY,       &TY_(W3CAttrsFor_BODY)[0],       (CM_HTML|CM_OPT|CM_OMITST),                    TY_(ParseBody),     NULL           },
   { TidyTag_BR,         "br",         VERS_ELEM_BR,         &TY_(W3CAttrsFor_BR)[0],         (CM_INLINE|CM_EMPTY),                          TY_(ParseEmpty),    NULL           },
-  { TidyTag_BUTTON,     "button",     VERS_ELEM_BUTTON,     &TY_(W3CAttrsFor_BUTTON)[0],     (CM_INLINE),                                   TY_(ParseBlock),    NULL           },
+  { TidyTag_BUTTON,     "button",     VERS_ELEM_BUTTON,     &TY_(W3CAttrsFor_BUTTON)[0],     (CM_INLINE),                                   TY_(ParseButton),   NULL           },
   { TidyTag_CAPTION,    "caption",    VERS_ELEM_CAPTION,    &TY_(W3CAttrsFor_CAPTION)[0],    (CM_TABLE),                                    TY_(ParseBlock),    CheckCaption   },
   { TidyTag_CENTER,     "center",     VERS_ELEM_CENTER,     &TY_(W3CAttrsFor_CENTER)[0],     (CM_BLOCK),                                    TY_(ParseBlock),    NULL           },
   { TidyTag_CITE,       "cite",       VERS_ELEM_CITE,       &TY_(W3CAttrsFor_CITE)[0],       (CM_INLINE),                                   TY_(ParseInline),   NULL           },

--- a/src/tags.h
+++ b/src/tags.h
@@ -104,6 +104,7 @@ Parser TY_(ParseList);
 Parser TY_(ParseDefList);
 Parser TY_(ParseBlock);
 Parser TY_(ParseInline);
+Parser TY_(ParseButton);
 Parser TY_(ParseEmpty);
 Parser TY_(ParseTableTag);
 Parser TY_(ParseColGroup);


### PR DESCRIPTION
HTML 5 restricts the children of <button> elements to only phrasing
content. HTML 4 also allowed block elements.

In particular, this change allows code such as

    <span><button>OK</button></span>

to be left as-is, since the <span> does not need duplication for
crossing a block boundary. Mitigates #461.