### PR TITLE
Add a flag to warn on proprietary attributes

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -632,6 +632,7 @@ typedef enum
     TidyUpperCaseTags,           /**< Output tags in upper not lower case */
     TidyUseCustomTags,           /**< Enable Tidy to use autonomous custom tags */
     TidyVertSpace,               /**< degree to which markup is spread out vertically */
+    TidyWarnPropAttrs,           /**< Warns on proprietary attributes */
     TidyWord2000,                /**< Draconian cleaning for Word2000 */
     TidyWrapAsp,                 /**< Wrap within ASP pseudo elements */
     TidyWrapAttVals,             /**< Wrap within attribute values */

--- a/src/config.c
+++ b/src/config.c
@@ -322,6 +322,7 @@ static const TidyOptionImpl option_defs[] =
     { TidyUpperCaseTags,           MU, "uppercase-tags",              BL, no,              ParseBool,         boolPicks       },
     { TidyUseCustomTags,           MU, "custom-tags",                 IN, TidyCustomNo,    ParseUseCustomTags,customTagsPicks }, /* 20170309 - Issue #119 */
     { TidyVertSpace,               PP, "vertical-space",              IN, no,              ParseAutoBool,     autoBoolPicks   }, /* #228 - tri option */
+    { TidyWarnPropAttrs,           MU, "warn-proprietary-attributes", BL, yes,             ParseBool,         boolPicks       },
     { TidyWord2000,                MU, "word-2000",                   BL, no,              ParseBool,         boolPicks       },
     { TidyWrapAsp,                 PP, "wrap-asp",                    BL, yes,             ParseBool,         boolPicks       },
     { TidyWrapAttVals,             PP, "wrap-attributes",             BL, no,              ParseBool,         boolPicks       },

--- a/src/language_en.h
+++ b/src/language_en.h
@@ -1304,6 +1304,17 @@ static languageDefinition language_en = { whichPluralForm_en, {
       - It's very important that <br/> be self-closing!
       - The strings "Tidy" and "HTML Tidy" are the program name and must not
       be translated. */
+        TidyWarnPropAttrs,            0,
+        "This option specifies if Tidy should warn on proprietary attributes."
+    },
+    {/* Important notes for translators:
+      - Use only <code></code>, <var></var>, <em></em>, <strong></strong>, and
+      <br/>.
+      - Entities, tags, attributes, etc., should be enclosed in <code></code>.
+      - Option values should be enclosed in <var></var>.
+      - It's very important that <br/> be self-closing!
+      - The strings "Tidy" and "HTML Tidy" are the program name and must not
+      be translated. */
         TidyWord2000,                 0,
         "This option specifies if Tidy should go to great pains to strip out all "
         "the surplus stuff Microsoft Word 2000 inserts when you save Word "

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1823,7 +1823,10 @@ void TY_(CheckHTMLTagsAttribsVersions)( TidyDocImpl* doc, Node* node )
                 attrIsMismatched = check_versions ? TY_(AttributeIsMismatched)(node, attval, doc) : no;
                 /* Let the PROPRIETARY_ATTRIBUTE warning have precedence. */
                 if ( attrIsProprietary )
-                    TY_(ReportAttrError)(doc, node, attval, PROPRIETARY_ATTRIBUTE);
+                {
+                    if ( cfgBool(doc, TidyWarnPropAttrs) )
+                        TY_(ReportAttrError)(doc, node, attval, PROPRIETARY_ATTRIBUTE);
+                }
                 else if ( attrIsMismatched )
                 {
                     TY_(ReportAttrError)(doc, node, attval, attrReportType);


### PR DESCRIPTION
This change adds the TidyWarnPropAttrs flag (default=on) that emits a
warning every proprietary attribute it finds.