### PR TITLE
Correctly process 'bookmarks' in html exported from Google Doc.

### DIFF
--- a/src/gdoc.c
+++ b/src/gdoc.c
@@ -115,6 +115,11 @@ static void CleanNode( TidyDocImpl* doc, Node *node )
                 else if (nodeIsA(child) && !child->content)
                  {
                     AttVal *id = TY_(GetAttrByName)( child, "name" );
+                    /* Recent Google Docs is using "id" instead of "name" in
+                    ** the exported html.
+                    */
+                    if (!id)
+                        id = TY_(GetAttrByName)( child, "id" );
 
                     if (id)
                         TY_(RepairAttrValue)( doc, child->parent, "id", id->value );


### PR DESCRIPTION
HTML exported from Google Docs contains empty anchors like ```<a id="random id"></a>```. They are used to "bookmark" any part of the document and make a link to it.

Looks like in the past (or for some specific documents) Google has used anchors like ```<a name="random id"></a>```, but now I don't see them any more.

Previous code moved "name" attribute to the parent "id" tag and deleted empty anchors. Proposed fix also supports "id" attribute in addition to "name".