### PR TITLE
Fix #338

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -2761,6 +2761,10 @@ static Bool CheckMetaData( TidyDocImpl* doc, Node* node, Bool HasMetaData )
                         TY_(ReportAccessError)( doc, node, REMOVE_AUTO_REDIRECT);
                     }
                 }
+                if (TY_(IsHTML5Mode)(doc) && attrIsCHARSET(av) && hasValue(av))
+                {
+                    ContainsAttr = yes;
+                }
             }
         
             if ( HasContent || HasHttpEquiv )
@@ -2840,9 +2844,17 @@ static void CheckDocType( TidyDocImpl* doc )
         if (DTnode && DTnode->end != 0)
         {
             ctmbstr word = textFromOneNode( doc, DTnode);
-            if ((strstr (word, "HTML PUBLIC") == NULL) &&
-                (strstr (word, "html PUBLIC") == NULL))
-                DTnode = NULL;
+            if (TY_(IsHTML5Mode)(doc))
+            {
+                if ((strstr(word, "HTML") == NULL) &&
+                    (strstr(word, "html") == NULL))
+                    DTnode = NULL;
+            }
+            else {
+                if ((strstr(word, "HTML PUBLIC") == NULL) &&
+                    (strstr(word, "html PUBLIC") == NULL))
+                    DTnode = NULL;
+            }
         }
         if (!DTnode)
            TY_(ReportAccessError)( doc, &doc->root, DOCTYPE_MISSING);


### PR DESCRIPTION
Issue #338 occurs because the existing routines assume that any URI with an extension is a file, and so links to TLD's ending with .pl, .au, etc., will cause accessibility warnings. This fix attempts to distinguish between URI's that are likely to be files versus links to domains.

Tested with `next` and no exit code regressions and nothing in the `diff`.

@geoff's test case in #338 now passes, and I would offer this as a new test case:

~~~
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>#338 - href with .au</title>
</head>
<body>
<p><a href="http://www.other.com.au/file.txt">(yes) Go to this site.</a></p>
<p><a href="mailto:something@other.com.au">(no) Mail Me</a></p>
<p><a href="http://www.other.com.au">(no) Go to this site.</a></p>
<p><a href="http://www.other.com/file.au">(yes) Link to this audio file.</a></p>
<p><a href="file.au">(yes) Link to this audio file (relative).</a></p>
<p><a href="/something/file.au">(yes) Link to this audio file (relative again).</a></p>
<p><a href="/something/file.au/">(no) Link to a directory.</a></p>
</body>
</html>
~~~