### PR TITLE
Add Travis-CI support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests"]
 	path = tests
-	url = https://github.com/lhchavez/tidy-html5-tests.git
+	url = https://github.com/htacg/tidy-html5-tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests"]
 	path = tests
-	url = https://github.com/htacg/tidy-html5-tests
+	url = https://github.com/htacg/tidy-html5-tests.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests"]
+	path = tests
+	url = https://github.com/lhchavez/tidy-html5-tests.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+
+dist: trusty
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - cmake
+
+script:
+  - (cd build/cmake && cmake ../.. -DCMAKE_BUILD_TYPE=Release && make)
+  - TY_TIDY_PATH=build/cmake/tidy TY_CASES_SETNAME=testbase ./tests/tools-sh/run-tests.sh


### PR DESCRIPTION
This change adds the tidy-html5-tests repository as a submodule and
makes Travis-CI run the full suite of tests on every commit and PR.

This change is intended to fix https://github.com/htacg/tidy-html5/issues/545,
but since this checks out the test repository as a submodule, there are two
downsides:

* Any commit that requires modifications to the tests would either appear
  as broken, or not receive automated coverage (in the case new tests are
  to be added).
* Every time the test repository is updated, the submodule must be uprevved.

This change also only runs the `testbase` set, because I could not find how to
run the others correctly.