### PR TITLE
Address #378

### DIFF
--- a/src/attrs.c
+++ b/src/attrs.c
@@ -1617,7 +1617,7 @@ void TY_(CheckUrl)( TidyDocImpl* doc, Node *node, AttVal *attval)
     {
         if ( cfgBool(doc, TidyFixUri) )
             TY_(ReportAttrError)( doc, node, attval, ESCAPED_ILLEGAL_URI);
-        else
+        else if ( !(TY_(HTMLVersion)(doc) & VERS_HTML5) )
             TY_(ReportAttrError)( doc, node, attval, ILLEGAL_URI_REFERENCE);
 
         doc->badChars |= BC_INVALID_URI;


### PR DESCRIPTION
Addresses issue #378 by NOT emitting warnings if `fix-uri` is `no`, for HTML5
documents. This preserves existing behavior for legacy document types.

Test on Windows, macOS, Ubuntu. Test cases added as PR in `tidy-html5-tests` repository.
