### PR TITLE
Fix NULL pointer issue with Word2000 empty attributes.

### DIFF
--- a/src/tmbstr.c
+++ b/src/tmbstr.c
@@ -126,6 +126,13 @@ int TY_(tmbstrcasecmp)( ctmbstr s1, ctmbstr s2 )
 
 int TY_(tmbstrncmp)( ctmbstr s1, ctmbstr s2, uint n )
 {
+    if (s1 == NULL || s2 == NULL)
+    {
+        if (s1 == s2)
+            return 0;
+        return (s1 == NULL ? -1 : 1);
+    }
+
     uint c;
 
     while ((c = (byte)*s1) == (byte)*s2)


### PR DESCRIPTION
This appears to be an issue with Word2000 handling of empty attributes.

A reproduction case can be seen here:

```
$ cat test.html
<html xmlns:o="urn:schemas-microsoft-com:office:office">
    <body>
        <table>
            <img class="" />
        </table>
    </body>
</html>

$ ./tidy --tidy-mark no --word-2000 yes test.html
line 1 column 1 - Warning: missing <!DOCTYPE> declaration
line 3 column 1 - Warning: <img> isn't allowed in <table> elements
line 2 column 1 - Info: <table> previously mentioned
line 1 column 57 - Warning: inserting missing 'title' element
line 3 column 1 - Warning: <img> lacks "alt" attribute
line 3 column 1 - Warning: <img> lacks "src" attribute
line 2 column 1 - Warning: trimming empty <table>
line 1 column 1 - Warning: <html> proprietary attribute "xmlns:o"
[2]    52405 segmentation fault  ./tidy --tidy-mark no --word-2000 yes test.html
```

This was called from https://github.com/htacg/tidy-html5/blob/6f2fb6e0e72c651978d9fc2efb0656670ccf9bf8/src/clean.c#L1710-L1747

(It is technically undefined behaviour to call strncmp with `NULL` pointers however).