### PR TITLE
Issue #594 - Parse XML element names beginning with Valid NameChar

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2696,7 +2696,7 @@ static Node* GetTokenFromStream( TidyDocImpl* doc, GetTokenMode mode )
 
                     TY_(AddCharToLexer)(lexer, c);
 
-                    if (TY_(IsLetter)(c))
+                    if (TY_(IsLetter)(c) || (cfgBool(doc, TidyXmlTags) && TY_(IsXMLNamechar)(c)))
                     {
                         lexer->lexsize -= 3;
                         lexer->txtend = lexer->lexsize;
@@ -2897,7 +2897,7 @@ static Node* GetTokenFromStream( TidyDocImpl* doc, GetTokenMode mode )
                 }
 
                 /* check for start tag */
-                if (TY_(IsLetter)(c))
+                if (TY_(IsLetter)(c) || (cfgBool(doc, TidyXmlTags) && TY_(IsXMLNamechar)(c)))
                 {
                     TY_(UngetChar)(c, doc->docIn);     /* push back letter */
                     TY_(UngetChar)('<', doc->docIn);


### PR DESCRIPTION
Patch for issue #594

Allow xml elements names to begin with valid non-letter name characters. 

This is a superset of the xml standard's defined NameStartChars. 
https://www.w3.org/TR/REC-xml/#NT-NameStartChar