### PR TITLE
Address #521

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -221,6 +221,7 @@ extern "C" {
     FN(MISSING_DOCTYPE)               \
     FN(MISSING_ENDTAG_BEFORE)         \
     FN(MISSING_ENDTAG_FOR)            \
+    FN(MISSING_ENDTAG_OPTIONAL)       \
     FN(MISSING_IMAGEMAP)              \
     FN(MISSING_QUOTEMARK)             \
     FN(MISSING_QUOTEMARK_OPEN)        \

--- a/localize/translations/tidy.pot
+++ b/localize/translations/tidy.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: HTML Tidy poconvert.rb\n"
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2017-09-28 13:24:51\n"
+"POT-Creation-Date: 2017-09-29 14:48:34\n"
 "Last-Translator: jderry\n"
 "Language-Team: \n"
 
@@ -2356,6 +2356,11 @@ msgstr ""
 #, c-format
 msgctxt "MISSING_ENDTAG_FOR"
 msgid "missing </%s>"
+msgstr ""
+
+#, c-format
+msgctxt "MISSING_ENDTAG_OPTIONAL"
+msgid "missing optional end tag </%s>"
 msgstr ""
 
 #, c-format

--- a/src/language_en.h
+++ b/src/language_en.h
@@ -1903,6 +1903,7 @@ static languageDefinition language_en = { whichPluralForm_en, {
     { MISSING_DOCTYPE,              0,   "missing <!DOCTYPE> declaration"                                          },
     { MISSING_ENDTAG_BEFORE,        0,   "missing </%s> before %s"                                                 },
     { MISSING_ENDTAG_FOR,           0,   "missing </%s>"                                                           },
+    { MISSING_ENDTAG_OPTIONAL,      0,   "missing optional end tag </%s>"                                          },
     { MISSING_IMAGEMAP,             0,   "%s should use client-side image map"                                     },
     { MISSING_QUOTEMARK,            0,   "%s attribute with missing trailing quote mark"                           },
     { MISSING_QUOTEMARK_OPEN,       0,   "value for attribute \"%s\" missing quote marks"                          },

--- a/src/message.c
+++ b/src/message.c
@@ -310,6 +310,7 @@ static struct _dispatchTable {
     { MISSING_DOCTYPE,              TidyWarning,     formatStandard          },
     { MISSING_ENDTAG_BEFORE,        TidyWarning,     formatStandard          },
     { MISSING_ENDTAG_FOR,           TidyWarning,     formatStandard          },
+    { MISSING_ENDTAG_OPTIONAL,      TidyInfo,        formatStandard          },
     { MISSING_IMAGEMAP,             TidyWarning,     formatAttributeReport   },
     { MISSING_QUOTEMARK,            TidyWarning,     formatAttributeReport   },
     { MISSING_QUOTEMARK_OPEN,       TidyInfo,        formatAttributeReport   },
@@ -814,6 +815,7 @@ TidyMessageImpl *formatStandard(TidyDocImpl* doc, Node *element, Node *node, uin
             return TY_(tidyMessageCreateWithNode)(doc, rpt, code, level, nodedesc );
 
         case MISSING_ENDTAG_FOR:
+        case MISSING_ENDTAG_OPTIONAL:
         case PREVIOUS_LOCATION:
             return TY_(tidyMessageCreateWithNode)(doc, rpt, code, level, element->element );
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -1267,6 +1267,11 @@ void TY_(ParseBlock)( TidyDocImpl* doc, Node *element, GetTokenMode mode)
 
                 if ( !TY_(nodeHasCM)(element, CM_OPT) && !element->implicit )
                     TY_(Report)(doc, element, node, MISSING_ENDTAG_BEFORE );
+                
+                /* #521, warn on missing optional end-tags if not omitting them. */
+                if ( cfgBool( doc, TidyOmitOptionalTags ) == no && TY_(nodeHasCM)(element, CM_OPT) )
+                    TY_(Report)(doc, element, node, MISSING_ENDTAG_OPTIONAL );
+
 
                 TY_(UngetToken)( doc );
 


### PR DESCRIPTION
  - Tidy will now emit a TidyInfo message when end tags are missing for li tags,
    unless omit-optional-tags is yes.