### PR TITLE
close stdin and free its FileSource in tidyDocParseStdin

### DIFF
--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1057,6 +1057,7 @@ int   tidyDocParseStdin( TidyDocImpl* doc )
 {
     StreamIn* in = TY_(FileInput)( doc, stdin, cfg( doc, TidyInCharEncoding ));
     int status = TY_(DocParseStream)( doc, in );
+    TY_(freeFileSource)(&in->source, yes);
     TY_(freeStreamIn)(in);
     return status;
 }


### PR DESCRIPTION
This caused a tiny memory leak.