### PR TITLE
Issue #646 - Correct 'INCLUDE_INSTALL_DIR' per 'master'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ if (NOT BIN_INSTALL_DIR)
 endif ()
 
 if (NOT INCLUDE_INSTALL_DIR)
-    set(INCLUDE_INSTALL_DIR include/${LIB_NAME})
+    set(INCLUDE_INSTALL_DIR include)
 endif ()
 
 


### PR DESCRIPTION
Addresses issue #646, correcting the header install location to as per released `master`...
