### PR TITLE
Issue 698 - docs update

### DIFF
--- a/man/tidy1.xsl.in
+++ b/man/tidy1.xsl.in
@@ -75,8 +75,9 @@ They are listed in the first part of this section.
 \fIConfiguration\fR options, on the other hand, can either be passed
 on the command line, starting with two dashes \fB--\fR,
 or specified in a configuration file,
-using the option name without the starting dashes.  
-They are listed in the second part of this section.
+using the option name, followed by a colon \fB:\fR, plus the value, without 
+the starting dashes. They are listed in the second part of this section,
+with a sample config file.
 .LP
 For \fIcommand-line\fR options that expect a numerical argument,
 a default is assumed if no meaningful value can be found.  


### PR DESCRIPTION
Per #698 mention the need for a colon, `:`, in a config file, and add that below there is a sample config to review...