### PR TITLE
Is #673 - Revert 350f7b4 and 86e62db AdjustConfig logic

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -303,6 +303,7 @@ static const struct {
 
 
 /* forward declarations */
+static void AdjustConfig( TidyDocImpl* doc );
 static Bool GetPickListValue( ctmbstr value, PickListItems* pickList, uint *result );
 
 
@@ -711,6 +712,7 @@ void TY_(TakeConfigSnapshot)( TidyDocImpl* doc )
     const TidyOptionValue* value = &doc->config.value[ 0 ];
     TidyOptionValue* snap  = &doc->config.snapshot[ 0 ];
 
+    AdjustConfig( doc );  /* Make sure it's consistent */
     for ( ixVal=0; ixVal < N_TIDY_OPTIONS; ++option, ++ixVal )
     {
         assert( ixVal == (uint) option->id );
@@ -759,6 +761,7 @@ void TY_(CopyConfig)( TidyDocImpl* docTo, TidyDocImpl* docFrom )
         }
         if ( needReparseTagsDecls )
             ReparseTagDecls( docTo, changedUserTags  );
+        AdjustConfig( docTo );  /* Make sure it's consistent */
     }
 }
 
@@ -1052,6 +1055,8 @@ int TY_(ParseConfigFileEnc)( TidyDocImpl* doc, ctmbstr file, ctmbstr charenc )
     if ( fname != (tmbstr) file )
         TidyDocFree( doc, fname );
 
+    AdjustConfig( doc );
+
     /* any new config errors? If so, return warning status. */
     return (doc->optionErrors > opterrs ? 1 : 0); 
 }
@@ -1190,7 +1195,7 @@ Bool  TY_(AdjustCharEncoding)( TidyDocImpl* doc, int encoding )
 
 
 /* ensure that config is self consistent */
-void TY_(AdjustConfig)( TidyDocImpl* doc )
+static void AdjustConfig( TidyDocImpl* doc )
 {
     if ( cfgBool(doc, TidyEncloseBlockText) )
         TY_(SetOptionBool)( doc, TidyEncloseBodyText, yes );

--- a/src/config.h
+++ b/src/config.h
@@ -335,12 +335,6 @@ Bool  TY_(ParseConfigValue)( TidyDocImpl* doc, TidyOptionId optId, ctmbstr optVa
 Bool  TY_(AdjustCharEncoding)( TidyDocImpl* doc, int encoding );
 
 
-/** Ensure that the configuration options are self consistent.
- ** @param doc The Tidy document to adjust.
- */
-void TY_(AdjustConfig)( TidyDocImpl* doc );
-
-
 /** Indicates whether or not the current configuration is completely default.
  ** @param doc The Tidy document.
  ** @returns The result.

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1447,7 +1447,6 @@ int         TY_(DocParseStream)( TidyDocImpl* doc, StreamIn* in )
 
     TY_(ResetTags)(doc);    /* reset table to html5 mode */
     TY_(TakeConfigSnapshot)( doc );    /* Save config state */
-    TY_(AdjustConfig)( doc ); /* ensure config consistency */
     TY_(FreeAnchors)( doc );
 
     TY_(FreeNode)(doc, &doc->root);


### PR DESCRIPTION
While these look like a code cleanup, they appear to have an adverse consequence in the use of libtidy by PHP 7+, so have been reverted. Changes in -

	modified:   src/config.c
	modified:   src/config.h
	modified:   src/tidylib.c

As indicated while these look like seemingly innocuous changes in AdjustConfig logic, it has caused  some very undesirable changes... see #704 for more details...

As stated in #673, unless a better fix is found will consider merging the `issue-673` to next...

Look forward to further feedback... thanks...
