### PR TITLE
Is #709 - Improve message if 'implict'

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -171,6 +171,7 @@ extern "C" {
 #define FOREACH_REPORT_MSG(FN)        \
     FN(ADDED_MISSING_CHARSET)         \
     FN(ANCHOR_NOT_UNIQUE)             \
+    FN(ANCHOR_DUPLICATED)             \
     FN(APOS_UNDEFINED)                \
     FN(ATTR_VALUE_NOT_LCASE)          \
     FN(ATTRIBUTE_IS_NOT_ALLOWED)      \

--- a/src/attrs.c
+++ b/src/attrs.c
@@ -1659,7 +1659,10 @@ void CheckName( TidyDocImpl* doc, Node *node, AttVal *attval)
 
         if ((old = GetNodeByAnchor(doc, attval->value)) &&  old != node)
         {
-            TY_(ReportAttrError)( doc, node, attval, ANCHOR_NOT_UNIQUE);
+            if (node->implicit) /* Is #709 - improve warning text */
+                TY_(ReportAttrError)(doc, node, attval, ANCHOR_DUPLICATED);
+            else
+                TY_(ReportAttrError)( doc, node, attval, ANCHOR_NOT_UNIQUE);
         }
         else
             AddAnchor( doc, attval->value, node );
@@ -1687,7 +1690,10 @@ void CheckId( TidyDocImpl* doc, Node *node, AttVal *attval )
 
     if ((old = GetNodeByAnchor(doc, attval->value)) &&  old != node)
     {
-        TY_(ReportAttrError)( doc, node, attval, ANCHOR_NOT_UNIQUE);
+        if (node->implicit) /* Is #709 - improve warning text */
+            TY_(ReportAttrError)(doc, node, attval, ANCHOR_DUPLICATED);
+        else
+            TY_(ReportAttrError)( doc, node, attval, ANCHOR_NOT_UNIQUE);
     }
     else
         AddAnchor( doc, attval->value, node );

--- a/src/language_en.h
+++ b/src/language_en.h
@@ -1924,6 +1924,7 @@ static languageDefinition language_en = { whichPluralForm_en, {
      ********************************************/    
     { ADDED_MISSING_CHARSET,        0,   "Added appropriate missing <meta charset=...> to %s"                      },
     { ANCHOR_NOT_UNIQUE,            0,   "%s anchor \"%s\" already defined"                                        },
+    { ANCHOR_DUPLICATED,            0,   "Implicit %s anchor \"%s\" duplicated by Tidy."                           },
     { APOS_UNDEFINED,               0,   "named entity &apos; only defined in XML/XHTML"                           },
     { ATTR_VALUE_NOT_LCASE,         0,   "%s attribute value \"%s\" must be lower case for XHTML"                  },
     { ATTRIBUTE_IS_NOT_ALLOWED,     0,   "%s attribute \"is\" not allowed for autonomous custom tags."             },

--- a/src/message.c
+++ b/src/message.c
@@ -261,6 +261,7 @@ static struct _dispatchTable {
 } dispatchTable[] = {
     { ADDED_MISSING_CHARSET,        TidyInfo,        formatStandard          },
     { ANCHOR_NOT_UNIQUE,            TidyWarning,     formatAttributeReport   },
+    { ANCHOR_DUPLICATED,            TidyWarning,     formatAttributeReport   },
     { APOS_UNDEFINED,               TidyWarning,     formatStandard          },
     { ATTR_VALUE_NOT_LCASE,         TidyWarning,     formatAttributeReport   },
     { ATTRIBUTE_VALUE_REPLACED,     TidyInfo,        formatAttributeReport   },
@@ -583,6 +584,7 @@ TidyMessageImpl *formatAttributeReport(TidyDocImpl* doc, Node *element, Node *no
             return TY_(tidyMessageCreateWithNode)(doc, node, code, level, tagdesc, name, HTMLVersion(doc));
 
         case ANCHOR_NOT_UNIQUE:
+        case ANCHOR_DUPLICATED:
         case ATTR_VALUE_NOT_LCASE:
         case PROPRIETARY_ATTR_VALUE:
         case XML_ID_SYNTAX:


### PR DESCRIPTION
Try to make it clear the `warning` is in html added by tidy during a **fixup**, and not in the original user input html...