### PR TITLE
Issue 726 upper case anchors

### DIFF
--- a/src/attrs.c
+++ b/src/attrs.c
@@ -997,13 +997,16 @@ void TY_(RemoveAnchorByNode)( TidyDocImpl* doc, ctmbstr name, Node *node )
     FreeAnchor( doc, delme );
 }
 
-/* initialize new anchor */
+/* initialize new anchor 
+   Is. #726 & #185 - HTML5 is case-sensitive
+*/
 static Anchor* NewAnchor( TidyDocImpl* doc, ctmbstr name, Node* node )
 {
     Anchor *a = (Anchor*) TidyDocAlloc( doc, sizeof(Anchor) );
 
     a->name = TY_(tmbstrdup)( doc->allocator, name );
-    a->name = TY_(tmbstrtolower)(a->name);
+    if (!TY_(IsHTML5Mode)(doc)) /* Is. #726 - if NOT HTML5, to lowercase */
+        a->name = TY_(tmbstrtolower)(a->name);
     a->node = node;
     a->next = NULL;
 


### PR DESCRIPTION
**WARNING** As mentioned in #726, the [regression](https://github.com/htacg/tidy-html5-tests) testing, with this new version, case **588061** now shows multiple **additional** warnings, for a duplicated anchor of "MAP details", which previous versions **missed**... 

The `expects` output needs to be adjusted at the same time this is merged...
