### PR TITLE
PHP ≥ 7.1.0 recognizes tidy-html5

### DIFF
--- a/README/BUILD.md
+++ b/README/BUILD.md
@@ -50,7 +50,7 @@ See the `CMakeLists.txt` file for other CMake **options** offered.
 
 ## Build PHP with the tidy-html5 library
 
-Due to API changes in the PHP source, `buffio.h` needs to be renamed to `tidybuffio.h` in the file `ext/tidy/tidy.c` in PHP's source.
+Before PHP 7.1, due to API changes in the PHP source, `buffio.h` needs to be renamed to `tidybuffio.h` in the file `ext/tidy/tidy.c` in PHP's source.
 
 That is - prior to configuring PHP run this in the PHP source directory:
 ~~~


### PR DESCRIPTION
Cf. php/php-src@a552ac5bd589035b66c899b74511b29a3d1a4718, which is
available as of PHP 7.1.0.