### PR TITLE
Issue 649 adding tag <data>

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -971,6 +971,7 @@ typedef enum
   TidyTag_BDI,           /**< BDI */
   TidyTag_CANVAS,        /**< CANVAS */
   TidyTag_COMMAND,       /**< COMMAND */
+  TidyTag_DATA,          /**< DATA */
   TidyTag_DATALIST,      /**< DATALIST */
   TidyTag_DETAILS,       /**< DETAILS */
   TidyTag_DIALOG,        /**< DIALOG */

--- a/src/attrdict.c
+++ b/src/attrdict.c
@@ -3395,6 +3395,17 @@ const AttrVersion TY_(W3CAttrsFor_TIME)[] =
   { TidyAttr_UNKNOWN,               0                                                                          },
 };
 
+const AttrVersion TY_(W3CAttrsFor_DATA)[] = 
+{
+  INCLUDE_ARIA
+  INCLUDE_MICRODATA
+  { TidyAttr_VALUE,              xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
+  INCLUDE_CORE_ATTRIBS
+  INCLUDE_CORE_EVENTS
+  INCLUDE_RDFA
+  { TidyAttr_UNKNOWN,               0                                                                          },
+};
+
 const AttrVersion TY_(W3CAttrsFor_TITLE)[] = 
 {
   INCLUDE_ARIA

--- a/src/attrdict.h
+++ b/src/attrdict.h
@@ -144,6 +144,7 @@ extern const AttrVersion TY_(W3CAttrsFor_METER)[];
 extern const AttrVersion TY_(W3CAttrsFor_PROGRESS)[];
 extern const AttrVersion TY_(W3CAttrsFor_TEMPLATE)[];
 extern const AttrVersion TY_(W3CAttrsFor_TIME)[];
+extern const AttrVersion TY_(W3CAttrsFor_DATA)[];
 extern const AttrVersion TY_(W3CAttrsFor_DATALIST)[];
 extern const AttrVersion TY_(W3CAttrsFor_AUDIO)[];
 extern const AttrVersion TY_(W3CAttrsFor_VIDEO)[];

--- a/src/tags.c
+++ b/src/tags.c
@@ -133,6 +133,7 @@ static CheckAttribs CheckHTML;
 #define VERS_ELEM_CANVAS     (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
 #define VERS_ELEM_COMMAND    (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
 #define VERS_ELEM_DATALIST   (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
+#define VERS_ELEM_DATA       (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
 #define VERS_ELEM_DETAILS    (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
 #define VERS_ELEM_DIALOG     (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
 #define VERS_ELEM_EMBED      (xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50)
@@ -302,6 +303,7 @@ static Dict tag_defs[] =
   { TidyTag_COMMAND,     "command",      VERS_ELEM_COMMAND,     &TY_(W3CAttrsFor_COMMAND)[0],     (CM_HEAD|CM_INLINE|CM_EMPTY),  TY_(ParseEmpty),     NULL           },
   { TidyTag_DATALIST,    "datalist",     VERS_ELEM_DATALIST,    &TY_(W3CAttrsFor_DATALIST)[0],    (CM_INLINE|CM_FIELD),          TY_(ParseDatalist),  NULL           },
   /* { TidyTag_DATALIST,    "datalist",     VERS_ELEM_DATALIST,    &TY_(W3CAttrsFor_DATALIST)[0],    (CM_FIELD),                   TY_(ParseInline),    NULL           },*/
+  { TidyTag_DATA,        "data",         VERS_ELEM_DATA,        &TY_(W3CAttrsFor_DATA)[0],        (CM_INLINE),                   TY_(ParseInline),    NULL           },
   { TidyTag_DETAILS,     "details",      VERS_ELEM_DETAILS,     &TY_(W3CAttrsFor_DETAILS)[0],     (CM_BLOCK),                    TY_(ParseBlock),     NULL           },
   { TidyTag_DIALOG,      "dialog",       VERS_ELEM_DIALOG,      &TY_(W3CAttrsFor_DIALOG)[0],      (CM_BLOCK),                    TY_(ParseBlock),     NULL           },
   { TidyTag_EMBED,       "embed",        VERS_ELEM_EMBED,       &TY_(W3CAttrsFor_EMBED)[0],       (CM_INLINE|CM_IMG|CM_EMPTY),   TY_(ParseEmpty),     NULL           },

--- a/src/tags.h
+++ b/src/tags.h
@@ -454,6 +454,7 @@ uint TY_(nodeHeaderLevel)( Node* node );
 
 /* HTML5 */
 #define nodeIsDATALIST( node )   TagIsId( node, TidyTag_DATALIST )
+#define nodeIsDATA( node )       TagIsId( node, TidyTag_DATA )
 #define nodeIsMATHML( node )     TagIsId( node, TidyTag_MATHML ) /* #130 MathML attr and entity fix! */
 
 /* NOT in HTML 5 */


### PR DESCRIPTION
The [&lt;data&gt;][1] element is similar to the [&lt;time&gt;][2] element.  The `<time>` element was used as a model for the changes to file [attrdict.c][3]

Other edits were as suggested in [TAGS.md][4] and [ATTRIBUTES.md][5], and this [comment][6] from @geoffmcl 

[1]: https://www.w3.org/TR/html5/text-level-semantics.html#the-data-element
[2]: https://www.w3.org/TR/html5/textlevel-semantics.html#the-time-element
[3]: https://github.com/AntoniosHadji/tidy-html5/blob/issue-649/src/attrdict.c#L3398
[4]: https://github.com/htacg/tidy-html5/blob/next/README/TAGS.md
[5]: https://github.com/htacg/tidy-html5/blob/next/README/ATTRIBUTES.md
[6]: https://github.com/htacg/tidy-html5/issues/649#issuecomment-435699352