### PR TITLE
delay calling AdjustConfig

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1056,8 +1056,6 @@ int TY_(ParseConfigFileEnc)( TidyDocImpl* doc, ctmbstr file, ctmbstr charenc )
     if ( fname != (tmbstr) file )
         TidyDocFree( doc, fname );
 
-    AdjustConfig( doc );
-
     /* any new config errors? If so, return warning status. */
     return (doc->optionErrors > opterrs ? 1 : 0); 
 }


### PR DESCRIPTION
Wait until after reading all the init files and parameters before calling AdjustConfig

Calling AdjustConfig right after reading an init file can break things since
tidy might not have the all of the config settings yet.  It needs to wait until
all the init files and parameters have been processed so that it can make it's
adjustments based on the full config.
ref: https://github.com/htacg/tidy-html5/issues/778