### PR TITLE
Is. #783 - Fix language detection

### DIFF
--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -36,6 +36,7 @@
 #include "attrs.h"
 #include "sprtf.h"
 #if SUPPORT_LOCALIZATIONS
+#  include "stdlib.h"
 #  include "locale.h"
 #endif
 
@@ -119,7 +120,13 @@ TidyDocImpl* tidyDocCreate( TidyAllocator *allocator )
 #if SUPPORT_LOCALIZATIONS
     if ( TY_(tidyGetLanguageSetByUser)() == no )
     {
-        TY_(tidySetLanguage)( setlocale( LC_ALL, "") );
+        if( ! TY_(tidySetLanguage)( getenv( "LC_MESSAGES" ) ) )
+        {
+            if( ! TY_(tidySetLanguage)( getenv( "LANG" ) ) )
+            {
+                TY_(tidySetLanguage)( setlocale( LC_ALL, "" ) );
+            }
+        }
     }
 #endif
 


### PR DESCRIPTION
The `setlocale` call doesn't return a single locale name in glibc when
any of the locale category variable has a different value, instead it
returns a composite locale name which is a concatenation of the entire
list of locale name and its values, seperated by a semicolon, which causing 
the language detection to fail.

This patch attempts to set the language via LC_MESSAGES and LANG
environment variables which are commonly used in POSIX-like systems,
then fallbacks to `setlocale` as the last resort.