### PR TITLE
Require itemprop, property, or rel on link element

### DIFF
--- a/src/tags.c
+++ b/src/tags.c
@@ -1012,13 +1012,14 @@ void CheckLINK( TidyDocImpl* doc, Node *node )
     Bool HasHref = TY_(AttrGetById)(node, TidyAttr_HREF) != NULL;
     Bool HasRel = TY_(AttrGetById)(node, TidyAttr_REL) != NULL;
     Bool HasItemprop = TY_(AttrGetById)(node, TidyAttr_ITEMPROP) != NULL;
+    Bool HasProperty = TY_(AttrGetById)(node, TidyAttr_PROPERTY) != NULL;
 
     if (!HasHref)
     {
       TY_(ReportMissingAttr)( doc, node, "href" );
     }
 
-    if (!HasItemprop && !HasRel)
+    if (!HasItemprop && !hasProperty && !HasRel)
     {
       TY_(ReportMissingAttr)( doc, node, "rel" );
     }


### PR DESCRIPTION
`<link itemprop="subject" href="../example">` in Microdata is equivalent to `<link property="subject" href="../example">` in RDFa. This HTML+RDFa syntax doesn’t trigger any errors or warnings from the W3C Nu Html Checker in HTML5 mode.

This change changes the requirement from `link[itemprop|rel]` to `link[itemprop|property|rel]` to support the HTML5+RDFa syntax.

See also: https://www.w3.org/TR/html-rdfa/#extensions-to-the-html5-syntax