### PR TITLE
Issue #816: tags_def not MT-safe

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -57,7 +57,7 @@ static Node* CleanNode( TidyDocImpl* doc, Node *node );
 
 static void RenameElem( TidyDocImpl* doc, Node* node, TidyTagId tid )
 {
-    const Dict* dict = TY_(LookupTagDef)( tid );
+    const Dict* dict = TY_(LookupTagDefForDoc)( doc, tid );
     TidyDocFree( doc, node->element );
     node->element = TY_(tmbstrdup)( doc->allocator, dict->name );
     node->tag = dict;
@@ -987,7 +987,7 @@ static Bool Dir2Div( TidyDocImpl* doc, Node *node, Node **ARG_UNUSED(pnode))
             return no;
 
         /* coerce dir to div */
-        node->tag = TY_(LookupTagDef)( TidyTag_DIV );
+        node->tag = TY_(LookupTagDefForDoc)( doc, TidyTag_DIV );
         TidyDocFree( doc, node->element );
         node->element = TY_(tmbstrdup)(doc->allocator, "div");
         TY_(AddStyleProperty)( doc, node, "margin-left: 2em" );
@@ -2029,7 +2029,7 @@ void TY_(CleanWord2000)( TidyDocImpl* doc, Node *node)
 
                 if ( !list || TagId(list) != listType )
                 {
-                    const Dict* tag = TY_(LookupTagDef)( listType );
+                    const Dict* tag = TY_(LookupTagDefForDoc)( doc, listType );
                     list = TY_(InferredTag)(doc, tag->id);
                     TY_(InsertNodeBeforeElement)(node, list);
                 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -2180,7 +2180,7 @@ Node* TY_(InferredTag)(TidyDocImpl* doc, TidyTagId id)
 {
     Lexer *lexer = doc->lexer;
     Node *node = TY_(NewNode)( lexer->allocator, lexer );
-    const Dict* dict = TY_(LookupTagDef)(id);
+    const Dict* dict = TY_(LookupTagDefForDoc)(doc, id);
 
     assert( dict != NULL );
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -72,7 +72,7 @@ Bool TY_(IsNewNode)(Node *node)
 
 void TY_(CoerceNode)(TidyDocImpl* doc, Node *node, TidyTagId tid, Bool obsolete, Bool unexpected)
 {
-    const Dict* tag = TY_(LookupTagDef)(tid);
+    const Dict* tag = TY_(LookupTagDefForDoc)(doc, tid);
     Node* tmp = TY_(InferredTag)(doc, tag->id);
 
     if (obsolete)
@@ -1150,7 +1150,7 @@ void TY_(ParseBlock)( TidyDocImpl* doc, Node *element, GetTokenMode mode)
                         node = element->parent;
                         TidyDocFree(doc, node->element);
                         node->element = TY_(tmbstrdup)(doc->allocator, "th");
-                        node->tag = TY_(LookupTagDef)( TidyTag_TH );
+                        node->tag = TY_(LookupTagDefForDoc)( doc, TidyTag_TH );
                         continue;
                     }
                 }
@@ -1738,7 +1738,7 @@ void TY_(ParseInline)( TidyDocImpl* doc, Node *element, GetTokenMode mode )
              )
            )
         {
-            node->tag = TY_(LookupTagDef)( TidyTag_BR );
+            node->tag = TY_(LookupTagDefForDoc)( doc, TidyTag_BR );
             TidyDocFree(doc, node->element);
             node->element = TY_(tmbstrdup)(doc->allocator, "br");
             TrimSpaces(doc, element);

--- a/src/tags.c
+++ b/src/tags.c
@@ -458,22 +458,26 @@ static void declare( TidyDocImpl* doc, TidyTagImpl* tags,
 {
     if ( name )
     {
-        Dict* np = (Dict*) tagsLookup( doc, tags, name );
+        /* Make sure we are not over-writing predefined tags */
+        /* Issue #815 - Corollary 1 to making global dict const */
+        /* Follow const-correctness for tagsLookup() */
+        Dict* npNew = NULL;
+        const Dict* np = tagsLookup( doc, tags, name );
         if ( np == NULL )
         {
-            np = NewDict( doc, name );
-            np->next = tags->declared_tag_list;
-            tags->declared_tag_list = np;
+            npNew = NewDict( doc, name );
         }
 
-        /* Make sure we are not over-writing predefined tags */
-        if ( np->id == TidyTag_UNKNOWN )
+        if ( npNew )
         {
-          np->versions = versions;
-          np->model   |= model;
-          np->parser   = parser;
-          np->chkattrs = chkattrs;
-          np->attrvers = NULL;
+            npNew->next = tags->declared_tag_list;
+            tags->declared_tag_list = npNew;
+
+            npNew->versions = versions;
+            npNew->model   |= model;
+            npNew->parser   = parser;
+            npNew->chkattrs = chkattrs;
+            npNew->attrvers = NULL;
         }
     }
 }

--- a/src/tags.c
+++ b/src/tags.c
@@ -174,7 +174,7 @@ static CheckAttribs CheckHTML;
  *
  * NOTE: If making changes to this table's entries, you MUST keep alt-entries in sync (as relevant for HTML4).
 \*/
-static Dict tag_defs[] =
+static const Dict tag_defs[] =
 {
   { TidyTag_UNKNOWN,    "unknown!",   VERS_UNKNOWN,         NULL,                       (0),                                           NULL,          NULL           },
 

--- a/src/tags.h
+++ b/src/tags.h
@@ -128,6 +128,14 @@ void TY_(DeclareUserTag)( TidyDocImpl* doc, const TidyOptionImpl* opt, ctmbstr n
  */
 const Dict* TY_(LookupTagDef)( TidyTagId tid );
 
+/** Interface for finding a tag by TidyTagId.
+ ** Unlike the above, it takes html-ness of doc into account.
+ ** @param doc The Tidy document.
+ ** @param tid The TidyTagId to search for.
+ ** @returns An instance of a Tidy tag.
+ */
+const Dict* TY_(LookupTagDefForDoc)( TidyDocImpl* doc, TidyTagId tid );
+
 /** Assigns the node's tag.
  ** @param doc The Tidy document.
  ** @param node The node to assign the tag to.


### PR DESCRIPTION
Issue #816

This addresses the "MT-safeness" of the tags_def, as far as I can tell. Tests pass, valgrind looks clean on the samples in the test repo (and there's no allocation happening here; no one owns memory, we just toggle where the hashtable points to, between the two global tables).

Let me know if you'd like to see any changes.