### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README/BUILD.md
+++ b/README/BUILD.md
@@ -40,6 +40,17 @@ If you do **not** need the tidy library built as a 'shared' (DLL) library, then 
 
 See the `CMakeLists.txt` file for other CMake **options** offered.
 
+Alternatively, you can build and install tidy using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+  1. `git clone https://github.com/Microsoft/vcpkg.git`
+  2. `cd vcpkg`
+  3. `./bootstrap-vcpkg.sh`
+  4. `./vcpkg integrate install`
+  5. `./vcpkg install tidy-html5`
+
+The tidy-html5 port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Build the tidy packages
 
   1. `cd build/cmake`


### PR DESCRIPTION
Tidy-html5 is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build tidy , ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for tidy-html5 and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.