### PR TITLE
Is. #879: add loading attribute for img, iframe

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -1082,6 +1082,7 @@ typedef enum
   TidyAttr_LAST_VISIT,             /**< LAST_VISIT= */
   TidyAttr_LEFTMARGIN,             /**< LEFTMARGIN= */
   TidyAttr_LINK,                   /**< LINK= */
+  TidyAttr_LOADING,                /**< LOADING= */
   TidyAttr_LONGDESC,               /**< LONGDESC= */
   TidyAttr_LOWSRC,                 /**< LOWSRC= */
   TidyAttr_MARGINHEIGHT,           /**< MARGINHEIGHT= */

--- a/src/attrdict.c
+++ b/src/attrdict.c
@@ -1630,6 +1630,7 @@ const AttrVersion TY_(W3CAttrsFor_IFRAME)[] =
   { TidyAttr_FRAMEBORDER,           xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_HEIGHT,                xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_ID,                    xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 }, /* CORE override */
+  { TidyAttr_LOADING,               xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_LONGDESC,              xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_MARGINHEIGHT,          xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_MARGINWIDTH,           xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx },
@@ -1663,6 +1664,7 @@ const AttrVersion TY_(W3CAttrsFor_IMG)[] =
   { TidyAttr_ID,                    xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|HT50|XH50 }, /* CORE override */
   { TidyAttr_ISMAP,                 HT20|HT32|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|xxxx|HT50|XH50 },
   { TidyAttr_LANG,                  xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|xxxx|xxxx|HT50|XH50 }, /* CORE override */
+  { TidyAttr_LOADING,               xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_LONGDESC,              xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|XB10|xxxx|xxxx },
   { TidyAttr_NAME,                  xxxx|xxxx|xxxx|H41T|X10T|xxxx|H41F|X10F|xxxx|H41S|xxxx|xxxx|xxxx|xxxx|xxxx },
   { TidyAttr_OnCLICK,               xxxx|xxxx|H40T|H41T|X10T|H40F|H41F|X10F|H40S|H41S|X10S|XH11|xxxx|HT50|XH50 }, /* CORE override */

--- a/src/attrs.c
+++ b/src/attrs.c
@@ -47,6 +47,7 @@ static AttrCheck CheckVType;
 static AttrCheck CheckScroll;
 static AttrCheck CheckTextDir;
 static AttrCheck CheckLang;
+static AttrCheck CheckLoading;
 static AttrCheck CheckType;
 static AttrCheck CheckRDFaSafeCURIE;
 static AttrCheck CheckRDFaTerm;
@@ -66,6 +67,7 @@ static AttrCheck CheckRDFaPrefix;
 #define CH_CLEAR       CheckClear
 #define CH_BORDER      CheckBool     /* kludge */
 #define CH_LANG        CheckLang
+#define CH_LOADING     CheckLoading
 #define CH_BOOL        CheckBool
 #define CH_COLS        NULL
 #define CH_NUMBER      CheckNumber
@@ -177,6 +179,7 @@ static const Attribute attribute_defs [] =
   { TidyAttr_LAST_VISIT,              "last_visit",              CH_PCDATA    }, /* A */
   { TidyAttr_LEFTMARGIN,              "leftmargin",              CH_NUMBER    }, /* used on BODY */
   { TidyAttr_LINK,                    "link",                    CH_COLOR     }, /* BODY */
+  { TidyAttr_LOADING,                 "loading",                 CH_LOADING   }, /* IMG, IFRAME */
   { TidyAttr_LONGDESC,                "longdesc",                CH_URL       }, /* IMG */
   { TidyAttr_LOWSRC,                  "lowsrc",                  CH_URL       }, /* IMG */
   { TidyAttr_MARGINHEIGHT,            "marginheight",            CH_NUMBER    }, /* FRAME, IFRAME, BODY */
@@ -2043,6 +2046,13 @@ void CheckLang( TidyDocImpl* doc, Node *node, AttVal *attval)
         }
         return;
     }
+}
+
+/* checks loading attribute */
+void CheckLoading( TidyDocImpl* doc, Node *node, AttVal *attval)
+{
+    ctmbstr const values[] = {"lazy", "eager", NULL};
+    CheckAttrValidity( doc, node, attval, values );
 }
 
 /* checks type attribute */


### PR DESCRIPTION
Fixes #879 

<details>
<summary>Test input</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <title>Document</title>
</head>
<body>
  <img src="foo" loading="lazy" alt="PASS">
  <img src="foo" loading="eager" alt="PASS">
  
  <iframe src="foo" loading="lazy">PASS</iframe>
  <iframe src="foo" loading="eager">PASS</iframe>
  
  <div loading="lazy">FAIL</div>
  <iframe src="foo" loading="what">FAIL</iframe>
  <img src="foo" loading="what" alt="FAIL">
  <img src="foo" loading="" alt="FAIL">
</body>
</html>
```

</details>

<details>
<summary><code>tidy -q test.html > /dev/null</code></summary>

```
line 7 column 3 - Warning: <img> proprietary attribute "loading"
line 8 column 3 - Warning: <img> proprietary attribute "loading"
line 10 column 3 - Warning: <iframe> proprietary attribute "loading"
line 11 column 3 - Warning: <iframe> proprietary attribute "loading"
line 13 column 3 - Warning: <div> proprietary attribute "loading"
line 14 column 3 - Warning: <iframe> proprietary attribute "loading"
line 15 column 3 - Warning: <img> proprietary attribute "loading"
line 16 column 3 - Warning: <img> proprietary attribute "loading"
```

</details>

<details>
<summary><code>./build/cmake/tidy -q test.html > /dev/null</code></summary>

```
line 14 column 3 - Warning: <iframe> attribute "loading" has invalid value "what"
line 15 column 3 - Warning: <img> attribute "loading" has invalid value "what"
line 16 column 3 - Warning: <img> attribute "loading" lacks value
line 13 column 3 - Warning: <div> proprietary attribute "loading"
```

</details>