### PR TITLE
Link macOS console application with required plist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,14 @@ if (SUPPORT_CONSOLE_APP)
     if (MSVC)
         set_target_properties( ${name} PROPERTIES DEBUG_POSTFIX d )
     endif ()
+    if (APPLE)
+        string(TIMESTAMP CURRENT_YEAR "%Y")
+        configure_file(
+            ${CMAKE_CURRENT_SOURCE_DIR}/console/Info.plist.in 
+            ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+        )
+        target_link_options(${name} PRIVATE LINKER:-sectcreate,__TEXT,__info_plist,Info.plist)
+    endif ()
     if (NOT TIDY_CONSOLE_SHARED)
         set_target_properties( ${name} PROPERTIES 
                                        COMPILE_FLAGS "-DTIDY_STATIC" )

--- a/build/cmake/.gitignore
+++ b/build/cmake/.gitignore
@@ -33,3 +33,4 @@ tidy1.xsl
 tidy.pc
 *.vcproj
 .pkg
+Info.plist

--- a/console/Info.plist.in
+++ b/console/Info.plist.in
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleDisplayName</key>
+        <string>HTML Tidy</string>
+        <key>CFBundleIdentifier</key>
+        <string>org.htacg.html-tidy.tidy5</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleShortVersionString</key>
+        <string>@LIBTIDY_VERSION@</string>
+        <key>CFBundleVersion</key>
+        <string>@LIBTIDY_DATE@</string>
+        <key>NSHumanReadableCopyright</key>
+        <string>©@CURRENT_YEAR@ HATCG and Contributors</string>
+</dict>
+</plist>

--- a/console/Info.plist.in
+++ b/console/Info.plist.in
@@ -13,6 +13,6 @@
         <key>CFBundleVersion</key>
         <string>@LIBTIDY_DATE@</string>
         <key>NSHumanReadableCopyright</key>
-        <string>©@CURRENT_YEAR@ HATCG and Contributors</string>
+        <string>©@CURRENT_YEAR@ HTACG and Contributors</string>
 </dict>
 </plist>


### PR DESCRIPTION
Add support for the required Info.plist to the Tidy console application, thus enabling
notarization support that's now required on macOS.

Unlike the similar pull request on the master branch, this one ensures that the proper
version is always used, via the same mechanism that CMakeLists uses to set the version.

Since there's now a 5.7.47 stable release, I'll build the macOS disk images with it.