### PR TITLE
Add muted and playsinline video attributes for HTML5.

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -1210,6 +1210,7 @@ typedef enum
   TidyAttr_MAX,                    /**< MAX= */
   TidyAttr_MEDIAGROUP,             /**< MEDIAGROUP= */
   TidyAttr_MIN,                    /**< MIN= */
+  TidyAttr_MUTED,                  /**< MUTED= */
   TidyAttr_NOVALIDATE,             /**< NOVALIDATE= */
   TidyAttr_OPEN,                   /**< OPEN= */
   TidyAttr_OPTIMUM,                /**< OPTIMUM= */
@@ -1265,6 +1266,7 @@ typedef enum
   TidyAttr_OnWAITING,              /**< OnWAITING= */
   TidyAttr_PATTERN,                /**< PATTERN= */
   TidyAttr_PLACEHOLDER,            /**< PLACEHOLDER= */
+  TidyAttr_PLAYSINLINE,            /**< PLAYSINLINE= */
   TidyAttr_POSTER,                 /**< POSTER= */
   TidyAttr_PRELOAD,                /**< PRELOAD= */
   TidyAttr_PUBDATE,                /**< PUBDATE= */

--- a/src/attrdict.c
+++ b/src/attrdict.c
@@ -3625,6 +3625,8 @@ const AttrVersion TY_(W3CAttrsFor_VIDEO)[] =
   { TidyAttr_HEIGHT,                xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_LOOP,                  xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_MEDIAGROUP,            xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
+  { TidyAttr_MUTED,                 xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
+  { TidyAttr_PLAYSINLINE,           xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_POSTER,                xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_PRELOAD,               xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },
   { TidyAttr_SRC,                   xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|xxxx|HT50|XH50 },

--- a/src/attrs.c
+++ b/src/attrs.c
@@ -317,6 +317,7 @@ static const Attribute attribute_defs [] =
   { TidyAttr_MAX,                     "max",                     CH_PCDATA   },
   { TidyAttr_MEDIAGROUP,              "mediagroup",              CH_PCDATA   },
   { TidyAttr_MIN,                     "min",                     CH_PCDATA   },
+  { TidyAttr_MUTED,                   "muted",                   CH_BOOL     },
   { TidyAttr_NOVALIDATE,              "novalidate",              CH_PCDATA   },
   { TidyAttr_OPEN,                    "open",                    CH_BOOL     }, /* Is. #925 PR #932 */
   { TidyAttr_OPTIMUM,                 "optimum",                 CH_PCDATA   },
@@ -372,6 +373,7 @@ static const Attribute attribute_defs [] =
   { TidyAttr_OnWAITING,               "onwaiting",               CH_PCDATA   },
   { TidyAttr_PATTERN,                 "pattern",                 CH_PCDATA   },
   { TidyAttr_PLACEHOLDER,             "placeholder",             CH_PCDATA   },
+  { TidyAttr_PLAYSINLINE,             "playsinline",             CH_BOOL     },
   { TidyAttr_POSTER,                  "poster",                  CH_PCDATA   },
   { TidyAttr_PRELOAD,                 "preload",                 CH_PCDATA   },
   { TidyAttr_PUBDATE,                 "pubdate",                 CH_PCDATA   },


### PR DESCRIPTION
Fix for video tag issues in #938.

Tested with this html file:

```
<!DOCTYPE html>
<html>
        <head>
                <meta charset="UTF-8">
                <title>Video Muted Attribute Test</title>
        </head>

        <body>
                <video autoplay loop muted playsinline>
                        <source src="video/Mine.mp4" type="video/mp4">
                </video>
        </body>
</html>
```

## Testing Done

Before changes, the output was:

```
debian ~/code/tidy-html5 (next)$ build/cmake/tidy -quiet -errors test.html
line 9 column 17 - Warning: <video> proprietary attribute "muted"
line 9 column 17 - Warning: <video> proprietary attribute "playsinline"
debian ~/code/tidy-html5 (next)$ echo $?
1
```

After changes, the output was:

```
debian ~/code/tidy-html5 (add-muted)$ build/cmake/tidy -quiet -errors test.html
debian ~/code/tidy-html5 (add-muted)$ echo $?
0
```