### PR TITLE
Fixes #743.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ if (LIBTIDY_VERSION)
     list(GET VERSION_LIST 0 TIDY_MAJOR_VERSION)
     list(GET VERSION_LIST 1 TIDY_MINOR_VERSION)
     list(GET VERSION_LIST 2 TIDY_POINT_VERSION)
+    set(TIDY_SO_VERSION "${TIDY_MAJOR_VERSION}${TIDY_MINOR_VERSION}")
 else ()
     message(FATAL_ERROR "*** FAILED to get a VERSION from version.txt!")
 endif ()   
@@ -66,6 +67,21 @@ if (LIBTIDY_DATE)
     list(GET DATE_LIST 2 tidy_DAY)
 else ()
     message(FATAL_ERROR "*** FAILED to get a DATE from version.txt!")
+endif ()
+
+# Establish SOVERSION. Tidy uses a weird form of semantic versioning,
+# wherein even minor versions are stable versions with SONAMEs, and
+# odd minor versions are `next` versions that should NOT be released,
+# are NOT stable, and should NOT have a valid SONAME.
+if (TIDY_SO_VERSION)
+    math(EXPR NO_SONAME "${TIDY_SO_VERSION} % 2")
+    if ( NO_SONAME EQUAL 0)
+        message("-> TIDY_SO_VERSION = ${TIDY_SO_VERSION}. This is an EVEN (stable) release.")
+    else ()
+        message("-> TIDY_SO_VERSION = ${TIDY_SO_VERSION}. This is an ODD (development) release.")
+    endif ()
+else ()
+    message(FATAL_ERROR "*** FAILED to build a TIDY_SO_VERSION!")
 endif ()
 
 
@@ -420,7 +436,8 @@ if (BUILD_SHARED_LIB)
                                    OUTPUT_NAME ${LIB_NAME} )
     set_target_properties( ${name} PROPERTIES
                                    VERSION   ${LIBTIDY_VERSION}
-                                   SOVERSION ${TIDY_MAJOR_VERSION} )
+                                   SOVERSION ${TIDY_SO_VERSION}
+                                   NO_SONAME ${NO_SONAME} )
     set_target_properties( ${name} PROPERTIES 
                                    COMPILE_FLAGS "-DBUILD_SHARED_LIB -DBUILDING_SHARED_LIB")
     install(TARGETS ${name}


### PR DESCRIPTION
- Only generates SOVERSION on stable (even minor version) releases.

- Guaranteed API/ABI stability for same SOVERSION from this point on.
- 