### PR TITLE
Fixes #523.

### DIFF
--- a/regression_testing/cases/github-cases/case-523.conf
+++ b/regression_testing/cases/github-cases/case-523.conf
@@ -1,0 +1,4 @@
+# Config for test case.
+tidy-mark: no
+indent: no
+wrap: 99999

--- a/regression_testing/cases/github-cases/case-523@1.html
+++ b/regression_testing/cases/github-cases/case-523@1.html
@@ -1,0 +1,28 @@
+<!--
+This test case is for issue #523, in which a space is placed after the
+closing tag of certain elements. For example below, a space is added after
+the first script closing tag and after the img tag.
+ -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>test</title>
+</head>
+<body>
+<script type="text/javascript">
+</script>
+<script type="text/javascript">
+</script>
+<h1>Hello</h1>
+<script type="text/javascript">
+</script>
+<img src="hi.jpg">
+<script type="text/javascript">
+</script>
+<p>This is a block level element, and as such, is capable of inlining inline elements.<script type="text/javascript">let x = "Hello, world"</script> Scripts are inline elements, so this script should be included in the flow.</p>
+<script type="text/javascript"></script><img src="bye.jpg"><script type="text/javascript"></script>
+<hr>
+<p>This is another paragraph with an <img src="meh.jpg"> tag inline.</p>
+<img src="one.jpg"><img src="two.jpg"><img src="three.jpg">
+</body>
+</html>

--- a/regression_testing/cases/github-expects/case-523.html
+++ b/regression_testing/cases/github-expects/case-523.html
@@ -1,0 +1,27 @@
+<!--
+This test case is for issue #523, in which a space is placed after the
+closing tag of certain elements. For example below, a space is added after
+the first script closing tag and after the img tag.
+ -->
+<!DOCTYPE html>
+<html>
+<head>
+<title>test</title>
+</head>
+<body>
+<script type="text/javascript"></script>
+<script type="text/javascript"></script>
+<h1>Hello</h1>
+<script type="text/javascript"></script><img src="hi.jpg">
+<script type="text/javascript"></script>
+<p>This is a block level element, and as such, is capable of inlining inline elements.
+<script type="text/javascript">
+let x = "Hello, world"
+</script> Scripts are inline elements, so this script should be included in the flow.</p>
+<script type="text/javascript"></script><img src="bye.jpg">
+<script type="text/javascript"></script>
+<hr>
+<p>This is another paragraph with an <img src="meh.jpg"> tag inline.</p>
+<img src="one.jpg"><img src="two.jpg"><img src="three.jpg">
+</body>
+</html>

--- a/regression_testing/cases/github-expects/case-523.txt
+++ b/regression_testing/cases/github-expects/case-523.txt
@@ -1,0 +1,26 @@
+line 19 column 1 - Warning: <img> lacks "alt" attribute
+line 23 column 41 - Warning: <img> lacks "alt" attribute
+line 25 column 38 - Warning: <img> lacks "alt" attribute
+line 26 column 1 - Warning: <img> lacks "alt" attribute
+line 26 column 20 - Warning: <img> lacks "alt" attribute
+line 26 column 39 - Warning: <img> lacks "alt" attribute
+Info: Document content looks like HTML5
+Tidy found 6 warnings and 0 errors!
+
+The alt attribute should be used to give a short description
+of an image; longer descriptions should be given with the
+longdesc attribute which takes a URL linked to the description.
+These measures are needed for people using non-graphical browsers.
+
+For further advice on how to make your pages accessible
+see https://www.w3.org/WAI/GL.
+About HTML Tidy: https://github.com/htacg/tidy-html5
+Bug reports and comments: https://github.com/htacg/tidy-html5/issues
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
+Latest HTML specification: https://html.spec.whatwg.org/multipage/
+Validate your HTML documents: https://validator.w3.org/nu/
+Lobby your company to join the W3C: https://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/regression_testing/cases/legacy-expects/case-443678.html
+++ b/regression_testing/cases/legacy-expects/case-443678.html
@@ -18,7 +18,7 @@
   </style>
 </head>
 <body>
-  Just a test. 
+  Just a test.
   <script>
 
   test();

--- a/src/parser.c
+++ b/src/parser.c
@@ -413,6 +413,14 @@ static Bool CleanLeadingWhitespace(TidyDocImpl* ARG_UNUSED(doc), Node* node)
 
     if (node->parent->tag && node->parent->tag->parser == TY_(ParseScript))
         return no;
+    
+    /* #523, prevent blank spaces after script if the next item is script.
+     * This is actually more generalized as, if the preceding element is
+     * a body level script, then indicate that we want to clean leading
+     * whitespace.
+     */
+    if ( node->prev && nodeIsSCRIPT(node->prev) && nodeIsBODY(node->prev->parent) )
+        return yes;
 
     /* <p>...<br> <em>...</em>...</p> */
     if (nodeIsBR(node->prev))
@@ -453,6 +461,14 @@ static Bool CleanTrailingWhitespace(TidyDocImpl* doc, Node* node)
 
     if (node->parent->tag && node->parent->tag->parser == TY_(ParseScript))
         return no;
+
+    /* #523, prevent blank spaces after script if the next item is script.
+     * This is actually more generalized as, if the next element is
+     * a body level script, then indicate that we want to clean trailing
+     * whitespace.
+     */
+    if ( node->next && nodeIsSCRIPT(node->next) && nodeIsBODY(node->next->parent) )
+        return yes;
 
     next = node->next;
 


### PR DESCRIPTION
Added test case to test flexibility.
Updated old test case 443678, which is better with this fix.

This fixes #523 and tries to be as general as possible. Right now the fix is
only applied if the prev or next tag is a body level div, but perhaps should
be applied for anything that's acting as block level element. In any case,
the specific bug is killed.