### PR TITLE
PPrintXMLTree: avoids infinite loop on root node with no content

### DIFF
--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2586,9 +2586,12 @@ void TY_(PPrintXMLTree)( TidyDocImpl* doc, uint mode, uint indent, Node *node )
         }
         else if ( node->type == RootNode )
         {
-            if (node->content)
+            if (node->content) {
                 node = node->content;
-            continue;
+                continue;
+            } else {
+                break;
+            }
         }
         else if ( node->type == CommentTag )
         {


### PR DESCRIPTION
This should fix oss-fuzz build failure
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36721

Because of this infinite loop, the target tidy_xml_fuzzer times out on an empty input and thus oss-fuzz considers the build as broken