### PR TITLE
makes sure that when building a target, its dependencies' PUBLIC and INTERFACE include directories will be used appropriately.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,7 @@ endif ()
 #------------------------------------------------------------------------
 set(name tidy-static)
 add_library ( ${name} STATIC ${CFILES} ${HFILES} ${LIBHFILES} )
+target_link_directories( ${name} PUBLIC "${PROJECT_SOURCE_DIR}/include")
 if (WIN32)
     set_target_properties( ${name} PROPERTIES 
                            OUTPUT_NAME ${LIB_NAME}_static ) 
@@ -427,6 +428,7 @@ if (BUILD_SHARED_LIB)
         set(CMAKE_MACOSX_RPATH 1)
     endif ()
     add_library ( ${name} SHARED ${CFILES} ${HFILES} ${LIBHFILES} )
+    target_link_directories( ${name} PUBLIC "${PROJECT_SOURCE_DIR}/include")
     set_target_properties( ${name} PROPERTIES 
                                    OUTPUT_NAME ${LIB_NAME} )
     set_target_properties( ${name} PROPERTIES


### PR DESCRIPTION
makes sure that when building a target, its dependencies' PUBLIC and INTERFACE include directories will be used appropriately.

See [https://stackoverflow.com/questions/40227333/cmake-setup-multiple-projects-and-dependiencies-between-them/40242257](url)