### PR TITLE
The itemtype attribute is a space-separated list

### DIFF
--- a/src/attrs.c
+++ b/src/attrs.c
@@ -180,7 +180,7 @@ static const Attribute attribute_defs [] =
   { TidyAttr_ITEMPROP,                "itemprop",                CH_PCDATA    },
   { TidyAttr_ITEMREF,                 "itemref",                 CH_PCDATA    },
   { TidyAttr_ITEMSCOPE,               "itemscope",               CH_BOOL      },
-  { TidyAttr_ITEMTYPE,                "itemtype",                CH_URL       },
+  { TidyAttr_ITEMTYPE,                "itemtype",                CH_PCDATA    },
   { TidyAttr_LABEL,                   "label",                   CH_PCDATA    }, /* OPT, OPTGROUP */
   { TidyAttr_LANG,                    "lang",                    CH_LANG      }, 
   { TidyAttr_LANGUAGE,                "language",                CH_PCDATA    }, /* SCRIPT */


### PR DESCRIPTION
The `itemtype` attribute accepts a space-separated list of URLs.
https://html.spec.whatwg.org/#attr-itemtype

Tidy incorrectly merges space-separated itemtype values into one value and URL-encodes the separator whitespace.

E.g. 

```
<div itemtype="https://schema.org/Organization https://schema.org/WebSite">
```

turns into 

```
<div itemtype="https://schema.org/Organization%20https://schema.org/WebSite">
```

This patch changes `CH_URL` to `CH_PCDATA`. (`CH_RDFATERMS`, used on the RDFa-equivalent `typeof` attribute, is the closest datatype, but it expects prefixes and not URLS. `CH_URLS` is the most similar data type, but it also allows comma-separated lists, which isn’t appropriate here. Switching to `CH_PCDATA` is better than leaving it broken.)