### PR TITLE
fixing a possible write beyond the array boundary.

### DIFF
--- a/src/tmbstr.c
+++ b/src/tmbstr.c
@@ -255,7 +255,7 @@ void TY_(strrep)(tmbstr buffer, ctmbstr str, ctmbstr rep)
         if(p)
         {
             char buf[1024];
-            memset(buf,'\0',strlen(buf));
+            memset(buf,'\0',sizeof(buf));
 
             if(buffer == p)
             {


### PR DESCRIPTION
If you don't initialize array `buf` and use `strlen` to determine the zero length, there is a possibility that the value of function `memset` will go beyond array `buf`. This will happen if there are no zeros in the declared array.