### PR TITLE
Use the found xsltproc executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,8 +509,8 @@ endif ()
 #################################################
 
 if (UNIX AND SUPPORT_CONSOLE_APP)
-    find_program( XSLTPROC_FOUND xsltproc )
-    if (XSLTPROC_FOUND)
+    find_program( LIBXSLT_XSLTPROC_EXECUTABLE xsltproc )
+    if (LIBXSLT_XSLTPROC_EXECUTABLE)
         ## NOTE: man name must match exe ie currently `${LIB_NAME}.1` not `tidy.1`
         ## also could use `manpath` command output to determine target install path
         set(TIDY_MANFILE ${LIB_NAME}.1)
@@ -546,7 +546,7 @@ if (UNIX AND SUPPORT_CONSOLE_APP)
         add_custom_command(
             TARGET man
             DEPENDS ${TIDYHELP}
-            COMMAND xsltproc ARGS ${TIDY1XSL} ${TIDYHELP} > ${CMAKE_CURRENT_BINARY_DIR}/${TIDY_MANFILE}
+            COMMAND "${LIBXSLT_XSLTPROC_EXECUTABLE}" ARGS ${TIDY1XSL} ${TIDYHELP} > ${CMAKE_CURRENT_BINARY_DIR}/${TIDY_MANFILE}
             COMMENT "Generate ${TIDY_MANFILE}"
             VERBATIM
         )


### PR DESCRIPTION
Noticed while updating the vcpkg port: `<program>_FOUND` doesn't mean it is found via the usual `PATH` environment variable. `find_program` searches more than `ENV{PATH}`, and it also considers the input (cache) variable. So the variable must actually be used.

The variable name is changed to match CMake's `FindLibXslt.cmake` module. But actually using that module is probably too much if only the program is needed.

Fixes #1065.