### PR TITLE
Use the found xsltproc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ if (UNIX AND SUPPORT_CONSOLE_APP)
         add_custom_command(
             TARGET man
             DEPENDS ${TIDYHELP}
-            COMMAND xsltproc ARGS ${TIDY1XSL} ${TIDYHELP} > ${CMAKE_CURRENT_BINARY_DIR}/${TIDY_MANFILE}
+            COMMAND ${XSLTPROC_FOUND} ARGS ${TIDY1XSL} ${TIDYHELP} > ${CMAKE_CURRENT_BINARY_DIR}/${TIDY_MANFILE}
             COMMENT "Generate ${TIDY_MANFILE}"
             VERBATIM
         )


### PR DESCRIPTION
Do not assume xsltproc is in PATH, and use the executable discovered by find_program().

Fixes #1065