### PR TITLE
fix: add final freeing of Stack to freeStack

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -1629,7 +1629,7 @@ void TY_(BQ2Div)( TidyDocImpl* doc, Node *node )
 
         node = next ? next : TY_(pop)(stack);
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 
 
@@ -2644,7 +2644,7 @@ void TY_(FixLanguageInformation)(TidyDocImpl* doc, Node* node, Bool wantXmlLang,
 
         node = next ? next : TY_(pop)(stack);
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 
 /*
@@ -2754,7 +2754,7 @@ void TY_(FixAnchors)(TidyDocImpl* doc, Node *node, Bool wantName, Bool wantId)
 
         node = next ? next : TY_(pop)(stack);
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 
 /* Issue #567 - move style elements from body to head 
@@ -2798,7 +2798,7 @@ static void StyleToHead(TidyDocImpl* doc, Node *head, Node *node, Bool fix, int 
             indent--;
         }
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 
 

--- a/src/gdoc.c
+++ b/src/gdoc.c
@@ -139,7 +139,7 @@ static void CleanNode( TidyDocImpl* doc, Node *node )
             }
             child = next ? next : TY_(pop)(stack);
         }
-        TY_(freeStack)(stack);
+        TY_(freeStack)(stack, doc);
     }
 }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -4538,11 +4538,12 @@ FUNC_UNUSED Node* TY_(peek)(Stack *stack)
 /**
  *  Frees the stack when done.
  */
-void TY_(freeStack)(Stack *stack)
+void TY_(freeStack)(Stack *stack, TidyDocImpl *doc)
 {
     TidyFree( stack->allocator, stack->firstNode );
     stack->top = -1;
     stack->capacity = 0;
     stack->firstNode = NULL;
     stack->allocator = NULL;
+    TidyFree( doc->allocator, stack)
 }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -731,7 +731,7 @@ TY_PRIVATE Node* TY_(peek)(Stack *stack);
 /**
  *  Frees the stack when done.
  */
-TY_PRIVATE void TY_(freeStack)(Stack *stack);
+TY_PRIVATE void TY_(freeStack)(Stack *stack, TidyDocImpl *doc);
 
 
 /** @}

--- a/src/parser.c
+++ b/src/parser.c
@@ -584,7 +584,7 @@ static void CleanSpaces(TidyDocImpl* doc, Node* node)
 
         node = next ? next : TY_(pop)(stack);
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 
 

--- a/src/tidylib.c
+++ b/src/tidylib.c
@@ -1804,7 +1804,7 @@ static void TY_(CheckHTML5)( TidyDocImpl* doc, Node* node )
 
         node = next ? next : TY_(pop)(stack);
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 /*****************************************************************************
  *  END HTML5 STUFF
@@ -1935,7 +1935,7 @@ static void TY_(CheckHTMLTagsAttribsVersions)( TidyDocImpl* doc, Node* node )
 
         node = next ? next : TY_(pop)(stack);
     }
-    TY_(freeStack)(stack);
+    TY_(freeStack)(stack, doc);
 }
 
 
@@ -2091,7 +2091,7 @@ void dbg_show_all_nodes( TidyDocImpl* doc, Node *node, int indent )
             }
 
         }
-        TY_(freeStack)(stack);
+        TY_(freeStack)(stack, doc);
     }
 }
 #endif


### PR DESCRIPTION
We noticed a memory leak when evaluating tidy w/ Valgrind. Together w/ @sameluch we determined the source of the leak to be a missing free of the Stack variable.

(Will add soon: valgrind of before and after the fix)