### PR TITLE
added script-no-first-blank-line option

### DIFF
--- a/include/tidyenum.h
+++ b/include/tidyenum.h
@@ -652,6 +652,7 @@ typedef enum
     TidyUpperCaseTags,           /**< Output tags in upper not lower case */
     TidyUseCustomTags,           /**< Enable Tidy to use autonomous custom tags */
     TidyVertSpace,               /**< degree to which markup is spread out vertically */
+    TidyScriptNoFirstBlankLine,  /**< Control blank line insertion after <script> tags */
     TidyWarnPropAttrs,           /**< Warns on proprietary attributes */
     TidyWord2000,                /**< Draconian cleaning for Word2000 */
     TidyWrapAsp,                 /**< Wrap within ASP pseudo elements */

--- a/src/config.c
+++ b/src/config.c
@@ -259,6 +259,7 @@ static const TidyOptionImpl option_defs[] =
     { TidyUpperCaseTags,           MR, "uppercase-tags",              BL, no,              ParsePickList,     &boolPicks          },
     { TidyUseCustomTags,           MR, "custom-tags",                 IN, TidyCustomNo,    ParsePickList,     &customTagsPicks    }, /* 20170309 - Issue #119 */
     { TidyVertSpace,               PP, "vertical-space",              IN, no,              ParsePickList,     &autoBoolPicks      }, /* #228 - tri option */
+    { TidyScriptNoFirstBlankLine,  PP, "script-no-first-blank-line",  BL, no,              ParsePickList,     &boolPicks          },
     { TidyWarnPropAttrs,           DG, "warn-proprietary-attributes", BL, yes,             ParsePickList,     &boolPicks          },
     { TidyWord2000,                MC, "word-2000",                   BL, no,              ParsePickList,     &boolPicks          },
     { TidyWrapAsp,                 PP, "wrap-asp",                    BL, yes,             ParsePickList,     &boolPicks          },

--- a/src/language_en.h
+++ b/src/language_en.h
@@ -1406,6 +1406,24 @@ static languageDefinition language_en = { whichPluralForm_en, {
       - It's very important that <br/> be self-closing!
       - The strings "Tidy" and "HTML Tidy" are the program name and must not
       be translated. */
+        TidyScriptNoFirstBlankLine,   0,
+        "This option controls whether Tidy adds a single blank line after the "
+        "<code>&lt;script&gt;</code> opening tag for readability. "
+        "<br/>"
+        "The default is <var>no</var>, which adds a single blank line after "
+        "the <code>&lt;script&gt;</code> tag. "
+        "<br/>"
+        "If set to <var>yes</var>, Tidy will suppress the blank line immediately "
+        "after the <code>&lt;script&gt;</code> tag."
+    },
+    {/* Important notes for translators:
+      - Use only <code></code>, <var></var>, <em></em>, <strong></strong>, and
+      <br/>.
+      - Entities, tags, attributes, etc., should be enclosed in <code></code>.
+      - Option values should be enclosed in <var></var>.
+      - It's very important that <br/> be self-closing!
+      - The strings "Tidy" and "HTML Tidy" are the program name and must not
+      be translated. */
         TidyWarnPropAttrs,            0,
         "This option specifies if Tidy should warn on proprietary attributes."
     },

--- a/src/pprint.c
+++ b/src/pprint.c
@@ -2139,7 +2139,10 @@ static void PPrintScriptStyle( TidyDocImpl* doc, uint mode, uint indent, Node *n
        In this case we don't want to flush the line, preferring to keep the required
        closing SCRIPT tag on the same line. */
     if ( node->content != NULL )
+    {
+      if (!cfgBool(doc, TidyScriptNoFirstBlankLine))
         PFlushLineSmart(doc, indent);
+    }
 
     if ( xhtmlOut && node->content != NULL )
     {


### PR DESCRIPTION
Added a new option that is leaving unchanged the first line after script so that 

```javascript
  <script>

  if ('serviceWorker' in navigator) {
    navigator.serviceWorker.register('/service-worker.min.js', { scope: '/' })
        .catch(error => console.error('Service Worker registration failed:', error));
  }
  </script>
  ```

is not becoming (if tidy is called in-place 3 times)
```javascript
  <script>




  if ('serviceWorker' in navigator) {
    navigator.serviceWorker.register('/service-worker.min.js', { scope: '/' })
        .catch(error => console.error('Service Worker registration failed:', error));
  }
  </script>
  ```
  
`--script-no-first-blank-line` is set to `no` by default (i.e. not changing the current behavior).

If I need to add test or any translation / file, please let me know.