### PR TITLE
CMakeLists: Adjust for CMake 4.0's removal of deprecated syntax.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # @date    Consult git log.
 ##############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.12...4.0)
 
 set(LIB_NAME tidy)
 set(LIBTIDY_DESCRIPTION "${LIB_NAME} - HTML syntax checker")
@@ -528,6 +528,7 @@ if (UNIX AND SUPPORT_CONSOLE_APP)
  
         # Run the built EXE to generate xml output .
         add_custom_command(
+            POST_BUILD
             TARGET man
             COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME} -xml-help > ${TIDYHELP}
             COMMENT "Generate ${TIDYHELP}"
@@ -536,6 +537,7 @@ if (UNIX AND SUPPORT_CONSOLE_APP)
 
         # Run the built EXE to generate more xml output.
         add_custom_command(
+            POST_BUILD
             TARGET man
             COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME} -xml-config > ${TIDYCONFIG}
             COMMENT "Generate ${TIDYCONFIG}"
@@ -544,8 +546,8 @@ if (UNIX AND SUPPORT_CONSOLE_APP)
 
         # Run xsltproc to generate the install files.
         add_custom_command(
+            POST_BUILD
             TARGET man
-            DEPENDS ${TIDYHELP}
             COMMAND xsltproc ARGS ${TIDY1XSL} ${TIDYHELP} > ${CMAKE_CURRENT_BINARY_DIR}/${TIDY_MANFILE}
             COMMENT "Generate ${TIDY_MANFILE}"
             VERBATIM


### PR DESCRIPTION
CMake 4.0 is more strict than previous versions, and has enforced removals of deprecated syntax. Compatibility with versions of CMake prior to 3.5 is no longer permitted either, so we'll change it to say 4.0 to fix that problem. After that, the custom commands for generating the manual page need to be adjusted as CMake now needs to know when to run commands, so we will generate the manual page after the package is built by passing POST_BUILD to the custom commands.

Tested with CMake 4.0 and 3.31.6.

Fixes #1139 