### PR TITLE
Lazy hot path lookup for entities

### DIFF
--- a/src/entities.c
+++ b/src/entities.c
@@ -2077,6 +2077,8 @@ static const entity entities[] =
     { NULL, VERS_UNKNOWN, 0 },
 };
 
+static entity* entity_lookup_by_initial[128];
+
 /* 
 ** Pure static implementation.  Trades off lookup speed
 ** for faster setup time (well, none actually).
@@ -2094,12 +2096,16 @@ static const entity* entitiesLookup( ctmbstr s )
     const entity *np = entities;
     if (ch == 0)
         return NULL;
-    while (np->name)
-    {
+
+    if (entity_lookup_by_initial[ch] == 0) {
+      while (np->name) {
         if (ch == *np->name)
-            break;  /* stop when first letter matches */
+          break; /* stop when first letter matches */
         np++;
+      }
+      entity_lookup_by_initial[ch] = np;
     }
+    np = entity_lookup_by_initial[ch];
     while (np->name)
     {
         if (ch != *np->name)


### PR DESCRIPTION
I noticed that ParseEntity was hot in the profiles of my workload and the only entity of interest was nbsp, which is pretty far down the list. This adds a lazily-constructed lookup table for the first character of the entity, preserving the overall strategy of ParseEntity but skipping the expensive scan for the 2nd and subsequent occurrences of any given entity.